### PR TITLE
Fixes #28: Backup & Restore fails for Azure with introduction of Availability Zone

### DIFF
--- a/lib/clients/AzureClient.py
+++ b/lib/clients/AzureClient.py
@@ -131,6 +131,7 @@ class AzureClient(BaseClient):
             instance = self.compute_client.virtual_machines.get(
                 self.resource_group, instance_id)
             self.instance_location = instance.location
+            self.availability_zones = instance.zones
             volume_list = []
             for disk in instance.storage_profile.data_disks:
                 device = None
@@ -260,7 +261,8 @@ class AzureClient(BaseClient):
                         'creation_data': {
                             'create_option': DiskCreateOption.copy,
                             'source_uri': snapshot.id
-                        }
+                        },
+                        'zones': self.availability_zones
                     }
                 )
             else:
@@ -275,7 +277,8 @@ class AzureClient(BaseClient):
                         'creation_data': {
                             'create_option': DiskCreateOption.empty
                         },
-                        'account_type': StorageAccountTypes.standard_lrs
+                        'account_type': StorageAccountTypes.standard_lrs,
+                        'zones': self.availability_zones
                     }
                 )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ python-cinderclient>=1.8.0, <1.9
 python-swiftclient>=3.0.0, <3.1
 retrying>=1.3.3, <1.4
 azure-common>=1.1.7, <1.1.8
-azure-mgmt-compute>=2.0.0, <2.1.0
+azure-mgmt-compute>=3.0.1, <3.1.0
 azure-storage>=0.35.1, <0.36.0
 google-auth==1.2.1
 google-api-python-client==1.6.4


### PR DESCRIPTION
Description:
Bumping the version of Azure mgmt compute library and passing zone
parameter while creating disk for restore