### PR TITLE
adding method to get instance location

### DIFF
--- a/lib/clients/AzureClient.py
+++ b/lib/clients/AzureClient.py
@@ -145,7 +145,6 @@ class AzureClient(BaseClient):
         try:
             instance = self.compute_client.virtual_machines.get(
                 self.resource_group, instance_id)
-            self.instance_location = instance.location
             self.availability_zones = instance.zones
             volume_list = []
             for disk in instance.storage_profile.data_disks:

--- a/lib/clients/AzureClient.py
+++ b/lib/clients/AzureClient.py
@@ -137,9 +137,9 @@ class AzureClient(BaseClient):
             return instance.location
         except Exception as error:
             self.logger.error(
-                '[Azure] ERROR: Unable to find or location for instance_id {}.{}'.format(
+                '[Azure] ERROR: Unable to get location for instance_id {}.{}'.format(
                     instance_id, error))
-            return none
+            return None
 
     def get_attached_volumes_for_instance(self, instance_id):
         try:


### PR DESCRIPTION
Requirement : If temp_volume size is retreived from snapshot_size instead of instance_size, then create-volume fails for azure. Reason: "none" returned for instance location"
Thus, adding a method, to get location