### PR TITLE
Improve RTO on AWS

### DIFF
--- a/lib/clients/AwsClient.py
+++ b/lib/clients/AwsClient.py
@@ -235,7 +235,7 @@ class AwsClient(BaseClient):
             self.logger.error(message)
             raise Exception(message)
 
-    def _create_volume(self, size, snapshot_id=None):
+    def _create_volume(self, size, snapshot_id=None, volume_type='standard'):
         log_prefix = '[VOLUME] [CREATE]'
         volume = None
 
@@ -243,7 +243,7 @@ class AwsClient(BaseClient):
             kwargs = {
                 'Size': size,
                 'AvailabilityZone': self.availability_zone,
-                'VolumeType': 'gp2'
+                'VolumeType': volume_type
             }
             if snapshot_id:
                 kwargs['SnapshotId'] = snapshot_id
@@ -265,8 +265,8 @@ class AwsClient(BaseClient):
                 Tags=self.formatted_tags
             )
 
-            self.logger.info('{} SUCCESS: volume-id={} with tags = {} '.format(
-                log_prefix, volume.id, self.formatted_tags))
+            self.logger.info('{} SUCCESS: volume-id={} volume-type={} with tags = {} '.format(
+                log_prefix, volume.id, volume_type, self.formatted_tags))
         except Exception as error:
             message = '{} ERROR: size={}\n{}'.format(log_prefix, size, error)
             self.logger.error(message)

--- a/lib/clients/AwsClient.py
+++ b/lib/clients/AwsClient.py
@@ -243,7 +243,7 @@ class AwsClient(BaseClient):
             kwargs = {
                 'Size': size,
                 'AvailabilityZone': self.availability_zone,
-                'VolumeType': 'standard'
+                'VolumeType': 'gp2'
             }
             if snapshot_id:
                 kwargs['SnapshotId'] = snapshot_id


### PR DESCRIPTION
* In order to reduce restore time, the disk type of  temporary disk (created from snapshot) has to be modified to type 'gp2'
* We have parametrised volume type, so that services can specify required type. Default is standard.
* Reg. cost issue, approval is sent in mail. 
