### PR TITLE
exposing credentials as an attribute for services use on demand

### DIFF
--- a/lib/clients/BaseClient.py
+++ b/lib/clients/BaseClient.py
@@ -84,7 +84,8 @@ class BaseClient:
         response = requests.get(url=configuration['credhub_url'].rstrip(
             '/') + '/v1/data', headers=headers, params=params, verify=False)
         credentials = response.json()
-        return credentials['data'][0]['value']
+        self.container_credentials = credentials['data'][0]['value']
+        return self.container_credentials
 
     def __getAccessToken(self, configuration):
         payload = {


### PR DESCRIPTION
exposing the attrib 'container_credentials' in iaas_client which is an utility for services to fetch credentials of the container on the fly if they want without having to directly invoke credhub apis.
Post initialization of iaasclient, this can be easily accessed.