### PR TITLE
Fix GCP / Azure backup failures as part credhub integration

### DIFF
--- a/lib/clients/AzureClient.py
+++ b/lib/clients/AzureClient.py
@@ -17,19 +17,22 @@ class AzureClient(BaseClient):
                  poll_maximum_time):
         super(AzureClient, self).__init__(operation_name, configuration, directory_persistent, directory_work_list,
                                           poll_delay_time, poll_maximum_time)
-        self.subscription_id = configuration['subscription_id']
         if configuration['credhub_url'] is None:
             self.__setCredentials(
                 configuration['client_id'], configuration['client_secret'], configuration['tenant_id'])
+            self.resource_group = configuration['resource_group']
+            self.storage_account_name = configuration['storageAccount']
+            self.storage_account_key = configuration['storageAccessKey']
+            self.subscription_id = configuration['subscription_id']
         else:
             self.logger.info('fetching creds from credhub')
-            credentials = self._get_credentials_from_credhub(configuration)
+            azure_config = self._get_credentials_from_credhub(configuration)
             self.__setCredentials(
-                credentials['client_id'], credentials['client_secret'], credentials['tenant_id'])
-
-        self.resource_group = configuration['resource_group']
-        self.storage_account_name = configuration['storageAccount']
-        self.storage_account_key = configuration['storageAccessKey']
+                azure_config['client_id'], azure_config['client_secret'], azure_config['tenant_id'])
+            self.resource_group = azure_config['resource_group']
+            self.storage_account_name = azure_config['storageAccount']
+            self.storage_account_key = azure_config['storageAccessKey']
+            self.subscription_id = azure_config['subscription_id']
 
         self.block_blob_service = BlockBlobService(
             account_name=self.storage_account_name, account_key=self.storage_account_key)

--- a/lib/clients/GcpClient.py
+++ b/lib/clients/GcpClient.py
@@ -17,9 +17,12 @@ class GcpClient(BaseClient):
 
         if configuration['credhub_url'] is None:
             self.__gcpCredentials = json.loads(configuration['credentials'])
+            self.project_id = configuration['projectId']
         else:
-            self.__gcpCredentials = self._get_credentials_from_credhub(
+            gcp_config = self._get_credentials_from_credhub(
                 configuration)
+            self.__gcpCredentials = gcp_config['credentials']
+            self.project_id = gcp_config['projectId']
 
         self.project_id = configuration['projectId']
 

--- a/lib/clients/GcpClient.py
+++ b/lib/clients/GcpClient.py
@@ -24,8 +24,6 @@ class GcpClient(BaseClient):
             self.__gcpCredentials = gcp_config['credentials']
             self.project_id = gcp_config['projectId']
 
-        self.project_id = configuration['projectId']
-
         self.compute_api_name = 'compute'
         self.compute_api_version = 'v1'
         self.device_path_template = '/dev/disk/by-id/google-{}'

--- a/tests/test_clients_GcpClient.py
+++ b/tests/test_clients_GcpClient.py
@@ -780,16 +780,19 @@ class TestGcpClient:
         mock_get.return_value.json.return_value = {
             'data': [{
                 'value': {
-                    'type': 'service_account',
-                    'project_id': 'gcp-dev',
-                    'private_key_id': '2222',
-                    'private_key': '-----BEGIN PRIVATE KEY-----\\nMIIEFatI0=\\n-----END PRIVATE KEY-----\\n',
-                    'client_email': 'user@gcp-dev.com',
-                    'client_id': '6666',
-                    'auth_uri': 'auth_uri',
-                    'token_uri': 'token_uri',
-                    'auth_provider_x509_cert_url': 'cert_url',
-                    'client_x509_cert_url': 'cert_url'}}]}
+                    'credentials': {
+                        'type': 'service_account',
+                        'project_id': 'gcp-dev',
+                        'private_key_id': '2222',
+                        'private_key': '-----BEGIN PRIVATE KEY-----\\nMIIEFatI0=\\n-----END PRIVATE KEY-----\\n',
+                        'client_email': 'user@gcp-dev.com',
+                        'client_id': '6666',
+                        'auth_uri': 'auth_uri',
+                        'token_uri': 'token_uri',
+                        'auth_provider_x509_cert_url': 'cert_url',
+                        'client_x509_cert_url': 'cert_url'},
+                    'projectId': 'gcp-dev'}
+                    }]}
         gcpClient = GcpClient(operation_name, credhub_config, directory_persistent, directory_work_list,
                   poll_delay_time, poll_maximum_time)
         assert gcpClient.project_id == project_id


### PR DESCRIPTION
Some of the attribs from credentials object were not being set during GcpClient and AzureClient creation. This is being fixed as part of this PR.