### PR TITLE
increased default poll_delay_time value

### DIFF
--- a/lib/clients/BaseClient.py
+++ b/lib/clients/BaseClient.py
@@ -62,7 +62,7 @@ class BaseClient:
 
         # Further initializations
         self.configuration = {
-            'poll_delay_time': poll_delay_time if poll_delay_time is not None else 5,
+            'poll_delay_time': poll_delay_time if poll_delay_time is not None else 10,
             'poll_maximum_time': poll_maximum_time if poll_maximum_time is not None else 300
         }
         self.__snapshots_ids = []


### PR DESCRIPTION
* To reduce the frequency at which iaas is polled to know the status of operation default value of 'poll_delay_time' is increased.