### PR TITLE
Fixing a bug in the Azure client

### DIFF
--- a/lib/clients/AzureClient.py
+++ b/lib/clients/AzureClient.py
@@ -61,12 +61,11 @@ class AzureClient(BaseClient):
                 msg = 'Could not determine SCSI host number for data volume'
                 self.last_operation(msg, 'failed')
                 raise Exception(msg)
+            self.availability_zones = self._get_availability_zone_of_server(configuration['instance_id'])
 
         self.max_block_size = 100 * 1024 * 1024
         #list of regions where ZRS is supported
         self.zrs_supported_regions = ['westeurope', 'centralus','southeastasia', 'eastus2', 'northeurope', 'francecentral']
-
-        self.availability_zones = self._get_availability_zone_of_server(configuration['instance_id'])
 
     def __setCredentials(self, client_id, client_secret, tenant_id):
         self.__azureCredentials = ServicePrincipalCredentials(


### PR DESCRIPTION
With blob-ops operation, there won't be an `instance-id` config parameter in the function invocation. However, for Azure IaaS client, one action (getting availability zone) was happening for blob-ops, thus failing in the process. This PR should fix the bug.