### PR TITLE
exposing new function to clear state (logs and last op) of previous operation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "3.5.2"
+  - "3.4.3"
 cache: pip3
 install:
   - pip3 install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "3.4.3"
+  - "3.5.2"
 cache: pip3
 install:
   - pip3 install -r requirements.txt

--- a/lib/clients/AliClient.py
+++ b/lib/clients/AliClient.py
@@ -10,7 +10,7 @@ class AliClient(BaseClient):
         if configuration['credhub_url'] is None:
             auth = oss2.Auth(configuration['access_key_id'], configuration['secret_access_key'])
             endpoint = configuration['endpoint']
-        else
+        else:
             credentials = self._get_credentials_from_credhub(configuration)
             auth = oss2.Auth(credentials['access_key_id'], credentials['secret_access_key'])
             endpoint = credentials['endpoint']

--- a/lib/clients/AliClient.py
+++ b/lib/clients/AliClient.py
@@ -1,0 +1,63 @@
+import oss2
+
+class AliClient(BaseClient):
+    def __init__(self, operation_name, configuration, directory_persistent, directory_work_list, poll_delay_time,
+                 poll_maximum_time):
+        super(AliClient, self).__init__(operation_name, configuration, directory_persistent, directory_work_list,
+                                        poll_delay_time, poll_maximum_time)
+        auth = oss2.Auth(configuration['access_key_id'], configuration['secret_access_key'])
+        # +-> Check whether the given container exists
+        self.container = self.get_container()
+        if not self.container:
+            msg = 'Could not find or access the given container.'
+            self.last_operation(msg, 'failed')
+            raise Exception(msg)
+
+    def get_container(self):
+        try:
+            container = oss2.Bucket(auth, configuration['endpoint'], self.CONTAINER)
+            # Test if the container is accessible
+            key = '{}/{}'.format(self.BLOB_PREFIX, 'AccessTestByServiceFabrikPythonLibrary')
+            bucket.put_object(key, 'This is a sample text')
+            bucket.delete_object(key)
+            return container
+        except Exception as error:
+            self.logger.error('[OSS] ERROR: Unable to find or access container {}.\n{}'.format(
+                self.CONTAINER, error))
+            return None
+
+    def _upload_to_blobstore(self, blob_to_upload_path, blob_target_name):
+        log_prefix = '[OSS] [UPLOAD]'
+
+        if self.container:
+            self.logger.info(
+                '{} Started to upload the tarball to the object storage.'.format(log_prefix))
+            try:
+                self.container.put_object(
+                    blob_to_upload_path, blob_target_name)
+                self.logger.info('{} SUCCESS: blob_to_upload={}, blob_target_name={}, container={}'
+                                 .format(log_prefix, blob_to_upload_path, blob_target_name, self.CONTAINER))
+                return True
+            except Exception as error:
+                message = '{} ERROR: blob_to_upload={}, blob_target_name={}, container={}\n{}'.format(
+                    log_prefix, blob_to_upload_path, blob_target_name, self.CONTAINER, error)
+                self.logger.error(message)
+                raise Exception(message)
+
+    def _download_from_blobstore(self, blob_to_download_name, blob_download_target_path):
+        log_prefix = '[OSS] [DOWNLOAD]'
+
+        if self.container:
+            self.logger.info('{} Started to download the tarball to target{}.'
+                             .format(log_prefix, blob_download_target_path))
+            try:
+                self.container.get_object(
+                    blob_to_download_name, blob_download_target_path).read()
+                self.logger.info('{} SUCCESS: blob_to_download={}, blob_target_name={}, container={}'.format(
+                    log_prefix, blob_to_download_name, self.CONTAINER, blob_download_target_path))
+                return True
+            except Exception as error:
+                message = '{} ERROR: blob_to_download={}, blob_target_name={}, container={}\n{}'.format(
+                    log_prefix, blob_to_download_name, blob_download_target_path, self.CONTAINER, error)
+                self.logger.error(message)
+                raise Exception(message)

--- a/lib/clients/AliClient.py
+++ b/lib/clients/AliClient.py
@@ -1,4 +1,6 @@
 import oss2
+from oss2.headers import RequestHeader
+from .BaseClient import BaseClient
 
 class AliClient(BaseClient):
     def __init__(self, operation_name, configuration, directory_persistent, directory_work_list, poll_delay_time,
@@ -7,19 +9,19 @@ class AliClient(BaseClient):
                                         poll_delay_time, poll_maximum_time)
         auth = oss2.Auth(configuration['access_key_id'], configuration['secret_access_key'])
         # +-> Check whether the given container exists
-        self.container = self.get_container()
+        self.container = self.get_container(auth, configuration)
         if not self.container:
             msg = 'Could not find or access the given container.'
             self.last_operation(msg, 'failed')
             raise Exception(msg)
 
-    def get_container(self):
+    def get_container(self, auth, configuration):
         try:
             container = oss2.Bucket(auth, configuration['endpoint'], self.CONTAINER)
             # Test if the container is accessible
             key = '{}/{}'.format(self.BLOB_PREFIX, 'AccessTestByServiceFabrikPythonLibrary')
-            bucket.put_object(key, 'This is a sample text')
-            bucket.delete_object(key)
+            container.put_object(key, 'This is a sample text')
+            container.delete_object(key)
             return container
         except Exception as error:
             self.logger.error('[OSS] ERROR: Unable to find or access container {}.\n{}'.format(
@@ -33,8 +35,9 @@ class AliClient(BaseClient):
             self.logger.info(
                 '{} Started to upload the tarball to the object storage.'.format(log_prefix))
             try:
-                self.container.put_object(
-                    blob_to_upload_path, blob_target_name)
+                requestHeader = RequestHeader()
+                requestHeader.set_server_side_encryption("AES256")
+                self.container.put_object_from_file(blob_target_name, blob_to_upload_path, headers=requestHeader)
                 self.logger.info('{} SUCCESS: blob_to_upload={}, blob_target_name={}, container={}'
                                  .format(log_prefix, blob_to_upload_path, blob_target_name, self.CONTAINER))
                 return True
@@ -60,4 +63,4 @@ class AliClient(BaseClient):
                 message = '{} ERROR: blob_to_download={}, blob_target_name={}, container={}\n{}'.format(
                     log_prefix, blob_to_download_name, blob_download_target_path, self.CONTAINER, error)
                 self.logger.error(message)
-                raise Exception(message)
+                raise Exception(message) 

--- a/lib/clients/AwsClient.py
+++ b/lib/clients/AwsClient.py
@@ -110,7 +110,7 @@ class AwsClient(BaseClient):
     def get_snapshot(self, snapshot_id):
         try:
             snapshot = self.ec2.Snapshot(snapshot_id)
-            return Snapshot(snapshot.id, snapshot.volume_size, snapshot.state)
+            return Snapshot(snapshot.id, snapshot.volume_size, snapshot.start_time, snapshot.state)
         except:
             return None
 
@@ -161,7 +161,7 @@ class AwsClient(BaseClient):
                        snapshot)
 
             snapshot = Snapshot(
-                snapshot.id, snapshot.volume_size, snapshot.state)
+                snapshot.id, snapshot.volume_size, snapshot.start_time, snapshot.state)
             self._add_snapshot(snapshot.id)
 
             self.ec2.create_tags(
@@ -203,7 +203,7 @@ class AwsClient(BaseClient):
                        new_snapshot)
 
             snapshot = Snapshot(
-                new_snapshot.id, new_snapshot.volume_size, new_snapshot.state)
+                new_snapshot.id, new_snapshot.volume_size, new_snapshot.start_time, new_snapshot.state)
             self.logger.info('{} SUCCESS: snapshot-id={}, unencrypted-snapshot_id={}'.format(
                 log_prefix, snapshot.id, snapshot_id))
             self.output_json['snapshotId'] = snapshot.id

--- a/lib/clients/AwsClient.py
+++ b/lib/clients/AwsClient.py
@@ -23,9 +23,11 @@ class AwsClient(BaseClient):
         self.max_retries = (configuration.get('max_retries') if
                             type(configuration.get('max_retries'))
                             == int else 10)
-        self.ec2_config = Config(retries={'max_attempts': self.max_retries})
-        self.ec2 = self.create_ec2_resource()
-        self.ec2.client = self.create_ec2_client()
+        # skipping some actions for blob operation
+        if operation_name != 'blob_operation':
+            self.ec2_config = Config(retries={'max_attempts': self.max_retries})
+            self.ec2 = self.create_ec2_resource()
+            self.ec2.client = self.create_ec2_client()
         self.s3 = self.create_s3_resource()
         self.s3.client = self.create_s3_client()
         self.formatted_tags = self.format_tags()

--- a/lib/clients/AwsClient.py
+++ b/lib/clients/AwsClient.py
@@ -32,7 +32,7 @@ class AwsClient(BaseClient):
         self.s3 = self.create_s3_resource()
         self.s3.client = self.create_s3_client()
         # +-> Check whether the given container exists
-        self.container = self.get_container(operation_name)
+        self.container = self.get_container()
         if not self.container:
             msg = 'Could not find or access the given container.'
             self.last_operation(msg, 'failed')
@@ -90,11 +90,11 @@ class AwsClient(BaseClient):
                 '[EC2] ERROR: Unable to determine the availability zone of instance {}.\n{}'.format(instance_id, error))
             return None
 
-    def get_container(self, operation_name):
+    def get_container(self):
         try:
             container = self.s3.Bucket(self.CONTAINER)
             # Test if the container is accessible
-            key = '{}/{}'.format(self.GUID, 'AccessTestByServiceFabrikPythonLibrary')
+            key = '{}/{}'.format(self.BLOB_PREFIX, 'AccessTestByServiceFabrikPythonLibrary')
             container.put_object(Key=key)
             container.delete_objects(Delete={
                'Objects': [{

--- a/lib/clients/AwsClient.py
+++ b/lib/clients/AwsClient.py
@@ -29,6 +29,9 @@ class AwsClient(BaseClient):
             self.ec2 = self.create_ec2_resource()
             self.ec2.client = self.create_ec2_client()
             self.formatted_tags = self.format_tags()
+
+        # add config for s3
+        self.s3_config = Config(retries={'max_attempts': self.max_retries})
         self.s3 = self.create_s3_resource()
         self.s3.client = self.create_s3_client()
         # +-> Check whether the given container exists
@@ -75,10 +78,10 @@ class AwsClient(BaseClient):
             raise Exception('Connection to AWS EC2 failed: {}'.format(error))
 
     def create_s3_resource(self):
-        return self.create_aws_session().resource('s3')
+        return self.create_aws_session().resource('s3', config=self.s3_config)
 
     def create_s3_client(self):
-        return self.create_aws_session().client('s3')
+        return self.create_aws_session().client('s3', config=self.s3_config)
 
     def _get_availability_zone_of_server(self, instance_id):
         try:

--- a/lib/clients/AzureClient.py
+++ b/lib/clients/AzureClient.py
@@ -89,7 +89,7 @@ class AzureClient(BaseClient):
     def access_container(self):
         # Test if the container is accessible
         try:
-            key = '{}/{}'.format(self.GUID,
+            key = '{}/{}'.format(self.BLOB_PREFIX,
                                  'AccessTestByServiceFabrikPythonLibrary')
             self.block_blob_service.create_blob_from_text(
                 self.CONTAINER,

--- a/lib/clients/AzureClient.py
+++ b/lib/clients/AzureClient.py
@@ -61,12 +61,11 @@ class AzureClient(BaseClient):
                 msg = 'Could not determine SCSI host number for data volume'
                 self.last_operation(msg, 'failed')
                 raise Exception(msg)
+            self.availability_zones = self._get_availability_zone_of_server(configuration['instance_id'])
 
         self.max_block_size = 100 * 1024 * 1024
         #list of regions where ZRS is supported
         self.zrs_supported_regions = ['westeurope', 'centralus','southeastasia', 'eastus2', 'northeurope', 'francecentral']
-
-        self.availability_zones = self._get_availability_zone_of_server(configuration['instance_id'])
 
     def __setCredentials(self, client_id, client_secret, tenant_id):
         self.__azureCredentials = ServicePrincipalCredentials(

--- a/lib/clients/AzureClient.py
+++ b/lib/clients/AzureClient.py
@@ -53,12 +53,14 @@ class AzureClient(BaseClient):
             msg = 'Could not determine SCSI host number for data volume'
             self.last_operation(msg, 'failed')
             raise Exception(msg)
-        self.instance_location = self.get_instance_location(
-            configuration['instance_id'])
-        if not self.instance_location:
-            msg = 'Could not retrieve the location of the instance.'
-            self.last_operation(msg, 'failed')
-            raise Exception(msg)
+        # skipping some actions for blob operation
+        if operation_name != 'blob_operation':
+            self.instance_location = self.get_instance_location(
+                configuration['instance_id'])
+            if not self.instance_location:
+                msg = 'Could not retrieve the location of the instance.'
+                self.last_operation(msg, 'failed')
+                raise Exception(msg)
 
         self.max_block_size = 100 * 1024 * 1024
         #list of regions where ZRS is supported

--- a/lib/clients/AzureClient.py
+++ b/lib/clients/AzureClient.py
@@ -267,7 +267,7 @@ class AzureClient(BaseClient):
             self.logger.info(
                 'Snapshot creation response: {}'.format(snapshot_info))
             snapshot = Snapshot(
-                snapshot_info.name, snapshot_info.disk_size_gb, snapshot.time_created, snapshot_info.provisioning_state)
+                snapshot_info.name, snapshot_info.disk_size_gb, snapshot_info.time_created, snapshot_info.provisioning_state)
             self._add_snapshot(snapshot.id)
             self.logger.info(
                 '{} SUCCESS: snapshot-id={}, volume-id={} , tags={} '.format(log_prefix, snapshot.id, volume_id, self.tags))

--- a/lib/clients/AzureClient.py
+++ b/lib/clients/AzureClient.py
@@ -118,7 +118,7 @@ class AzureClient(BaseClient):
         try:
             snapshot = self.compute_client.snapshots.get(
                 self.resource_group, snapshot_name)
-            return Snapshot(snapshot.name, snapshot.disk_size_gb, snapshot.provisioning_state)
+            return Snapshot(snapshot.name, snapshot.disk_size_gb, snapshot.time_created, snapshot.provisioning_state)
         except Exception as error:
             self.logger.error(
                 '[Azure] ERROR: Unable to find or access snapshot {}.\n{}'.format(
@@ -267,7 +267,7 @@ class AzureClient(BaseClient):
             self.logger.info(
                 'Snapshot creation response: {}'.format(snapshot_info))
             snapshot = Snapshot(
-                snapshot_info.name, snapshot_info.disk_size_gb, snapshot_info.provisioning_state)
+                snapshot_info.name, snapshot_info.disk_size_gb, snapshot.time_created, snapshot_info.provisioning_state)
             self._add_snapshot(snapshot.id)
             self.logger.info(
                 '{} SUCCESS: snapshot-id={}, volume-id={} , tags={} '.format(log_prefix, snapshot.id, volume_id, self.tags))

--- a/lib/clients/BaseClient.py
+++ b/lib/clients/BaseClient.py
@@ -29,7 +29,7 @@ class BaseClient:
                 'job_name': self.JOB_NAME
                 }
         else:
-            self.GUID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
+            self.GUID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' + str(time.time())
         
         self.CONTAINER = configuration['container']
         self.TYPE = configuration['type']

--- a/lib/clients/BaseClient.py
+++ b/lib/clients/BaseClient.py
@@ -57,12 +57,11 @@ class BaseClient:
 
         # Writing the last operation file
         initialize(operation_name)
-        if operation_name != 'blob_operation':
-            self.LAST_OPERATION_DIRECTORY = os.getenv(
-                'SF_BACKUP_RESTORE_LAST_OPERATION_DIRECTORY')
-            self.last_operation(
-                'Initializing Backup & Restore Library ...', 'processing')
+        self.LAST_OPERATION_DIRECTORY = os.getenv(
+            'SF_BACKUP_RESTORE_LAST_OPERATION_DIRECTORY')
         self.LOG_DIRECTORY = os.getenv('SF_BACKUP_RESTORE_LOG_DIRECTORY')
+        self.last_operation(
+            'Initializing Backup & Restore Library ...', 'processing')
         self.logger = create_logger(self)
         self.output_json = dict()
         self.json_output()

--- a/lib/clients/BaseClient.py
+++ b/lib/clients/BaseClient.py
@@ -20,6 +20,7 @@ class BaseClient:
         # Skipping some parameters for blob operation.
         if operation_name != 'blob_operation':
             self.GUID = configuration['backup_guid']
+            self.BLOB_PREFIX = self.GUID
             self.INSTANCE_ID = configuration['instance_id']
             self.SECRET = configuration['secret']
             self.JOB_NAME = configuration['job_name']
@@ -29,7 +30,7 @@ class BaseClient:
                 'job_name': self.JOB_NAME
                 }
         else:
-            self.GUID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' + str(time.time())
+            self.BLOB_PREFIX = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa' + str(time.time())
         
         self.CONTAINER = configuration['container']
         self.TYPE = configuration['type']

--- a/lib/clients/BaseClient.py
+++ b/lib/clients/BaseClient.py
@@ -21,13 +21,13 @@ class BaseClient:
         if operation_name != 'blob_operation':
             self.GUID = configuration['backup_guid']
             self.INSTANCE_ID = configuration['instance_id']
+            self.SECRET = configuration['secret']
+            self.JOB_NAME = configuration['job_name']
             self.tags = {
                 'created_by': 'service-fabrik-backup-restore',
                 'instance_id': self.INSTANCE_ID,
                 'job_name': self.JOB_NAME
                 }
-            self.SECRET = configuration['secret']
-            self.JOB_NAME = configuration['job_name']
         else:
             self.GUID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
         

--- a/lib/clients/BaseClient.py
+++ b/lib/clients/BaseClient.py
@@ -57,11 +57,12 @@ class BaseClient:
 
         # Writing the last operation file
         initialize(operation_name)
-        self.LAST_OPERATION_DIRECTORY = os.getenv(
-            'SF_BACKUP_RESTORE_LAST_OPERATION_DIRECTORY')
+        if operation_name != 'blob_operation':
+            self.LAST_OPERATION_DIRECTORY = os.getenv(
+                'SF_BACKUP_RESTORE_LAST_OPERATION_DIRECTORY')
+            self.last_operation(
+                'Initializing Backup & Restore Library ...', 'processing')
         self.LOG_DIRECTORY = os.getenv('SF_BACKUP_RESTORE_LOG_DIRECTORY')
-        self.last_operation(
-            'Initializing Backup & Restore Library ...', 'processing')
         self.logger = create_logger(self)
         self.output_json = dict()
         self.json_output()

--- a/lib/clients/BaseClient.py
+++ b/lib/clients/BaseClient.py
@@ -68,7 +68,7 @@ class BaseClient:
 
         # Further initializations
         self.configuration = {
-            'poll_delay_time': poll_delay_time if poll_delay_time is not None else 5,
+            'poll_delay_time': poll_delay_time if poll_delay_time is not None else 10,
             'poll_maximum_time': poll_maximum_time if poll_maximum_time is not None else 300
         }
         self.__snapshots_ids = []

--- a/lib/clients/BaseClient.py
+++ b/lib/clients/BaseClient.py
@@ -17,7 +17,10 @@ class BaseClient:
     def __init__(self, operation_name, configuration, directory_persistent, directory_work_list, poll_delay_time,
                  poll_maximum_time):
         self.OPERATION = operation_name
-        self.GUID = configuration['backup_guid']
+        # Skipping some parameters for blob operation.
+        if operation_name != 'blob_operation':
+            self.GUID = configuration['backup_guid']
+        
         self.CONTAINER = configuration['container']
         self.SECRET = configuration['secret']
         self.TYPE = configuration['type']

--- a/lib/clients/BaseClient.py
+++ b/lib/clients/BaseClient.py
@@ -20,12 +20,19 @@ class BaseClient:
         # Skipping some parameters for blob operation.
         if operation_name != 'blob_operation':
             self.GUID = configuration['backup_guid']
+            self.INSTANCE_ID = configuration['instance_id']
+            self.tags = {
+                'created_by': 'service-fabrik-backup-restore',
+                'instance_id': self.INSTANCE_ID,
+                'job_name': self.JOB_NAME
+                }
+            self.SECRET = configuration['secret']
+            self.JOB_NAME = configuration['job_name']
+        else:
+            self.GUID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'
         
         self.CONTAINER = configuration['container']
-        self.SECRET = configuration['secret']
         self.TYPE = configuration['type']
-        self.JOB_NAME = configuration['job_name']
-        self.INSTANCE_ID = configuration['instance_id']
         self.DIRECTORY_PERSISTENT = directory_persistent
         self.DIRECTORY_WORK_LIST = directory_work_list
         self.DIRECTORY_DATA = '/var/vcap/data'
@@ -33,19 +40,15 @@ class BaseClient:
         self.DEVICE_PATH_TEMPLATE = '/sys/bus/scsi/devices/{}:*:*:{}/block'
         self.SNAPSHOT_PREFIX = 'sf-snapshot'
         self.DISK_PREFIX = 'sf-disk'
-        self.tags = {
-                'created_by': 'service-fabrik-backup-restore',
-                'instance_id': self.INSTANCE_ID,
-                'job_name': self.JOB_NAME
-                }
         assert len(
             self.OPERATION) > 0, 'No operation name (backup or restore) given.'
         assert len(
             self.DIRECTORY_PERSISTENT) > 0, 'Directory of the persistent volume not given.'
         assert len(self.DIRECTORY_WORK_LIST) > 0, 'Directory Worklist not given.'
         assert len(self.CONTAINER) > 0, 'No container given.'
-        assert len(self.SECRET) > 0, 'No encryption secret given.'
-        assert len(self.JOB_NAME) > 0, 'No service job name given.'
+        if operation_name != 'blob_operation':
+            assert len(self.SECRET) > 0, 'No encryption secret given.'
+            assert len(self.JOB_NAME) > 0, 'No service job name given.'
 
         # Handling abort signals
         self.__ABORT = False
@@ -228,10 +231,11 @@ class BaseClient:
                 iaas_client.initialize()
                 iaas_client.initialize('A log messages before the program begins.')
         """
-        self.logger.info('[{}] [START] (backup-type={})] Time: {}'.format(
-            self.OPERATION.upper(), self.TYPE, time.strftime("%Y-%m-%dT%H-%M-%SZ")))
-        self.logger.info('Backup guid: {}, Name of container: {}'.format(
-            self.GUID, self.CONTAINER))
+        if self.OPERATION != 'blob_operation':
+            self.logger.info('[{}] [START] (backup-type={})] Time: {}'.format(
+                self.OPERATION.upper(), self.TYPE, time.strftime("%Y-%m-%dT%H-%M-%SZ")))
+            self.logger.info('Backup guid: {}, Name of container: {}'.format(
+                self.GUID, self.CONTAINER))
         if message:
             self.logger.info(message)
 

--- a/lib/clients/GcpClient.py
+++ b/lib/clients/GcpClient.py
@@ -39,13 +39,15 @@ class GcpClient(BaseClient):
             self.last_operation(msg, 'failed')
             raise Exception(msg)
 
-        # +-> Get the availability zone of the instance
-        self.availability_zone = self._get_availability_zone_of_server(
-            configuration['instance_id'])
-        if not self.availability_zone:
-            msg = 'Could not retrieve the availability zone of the instance.'
-            self.last_operation(msg, 'failed')
-            raise Exception(msg)
+        # skipping some actions for blob operation
+        if operation_name != 'blob_operation':
+            # +-> Get the availability zone of the instance
+            self.availability_zone = self._get_availability_zone_of_server(
+                configuration['instance_id'])
+            if not self.availability_zone:
+                msg = 'Could not retrieve the availability zone of the instance.'
+                self.last_operation(msg, 'failed')
+                raise Exception(msg)
 
     def create_compute_client(self):
         try:

--- a/lib/clients/GcpClient.py
+++ b/lib/clients/GcpClient.py
@@ -8,6 +8,8 @@ from ..models.Volume import Volume
 from ..models.Attachment import Attachment
 import json
 import glob
+import iso8601
+import pytz
 
 class GcpClient(BaseClient):
     def __init__(self, operation_name, configuration, directory_persistent, directory_work_list, poll_delay_time,
@@ -115,7 +117,9 @@ class GcpClient(BaseClient):
         try:
             snapshot = self.compute_client.snapshots().get(
                 project=self.project_id, snapshot=snapshot_name).execute()
-            return Snapshot(snapshot['name'], snapshot['diskSizeGb'], snapshot['creationTimestamp'], snapshot['status'])
+            snapshot_creation_time_obj=iso8601.parse_date(snapshot['creationTimestamp'])
+            snapshot_creation_time_utc=snapshot_creation_time_obj.astimezone(pytz.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+            return Snapshot(snapshot['name'], snapshot['diskSizeGb'], snapshot_creation_time_utc, snapshot['status'])
         except Exception as error:
             message = '[GCP] ERROR: Unable to get snapshot {}.\n{}'.format(
                 snapshot_name, error)

--- a/lib/clients/GcpClient.py
+++ b/lib/clients/GcpClient.py
@@ -115,7 +115,7 @@ class GcpClient(BaseClient):
         try:
             snapshot = self.compute_client.snapshots().get(
                 project=self.project_id, snapshot=snapshot_name).execute()
-            return Snapshot(snapshot['name'], snapshot['diskSizeGb'], snapshot['status'])
+            return Snapshot(snapshot['name'], snapshot['diskSizeGb'], snapshot['creationTimestamp'], snapshot['status'])
         except Exception as error:
             message = '[GCP] ERROR: Unable to get snapshot {}.\n{}'.format(
                 snapshot_name, error)

--- a/lib/clients/GcpClient.py
+++ b/lib/clients/GcpClient.py
@@ -99,7 +99,7 @@ class GcpClient(BaseClient):
         try:
             container = self.storage_client.get_bucket(self.CONTAINER)
             # Test if the container is accessible
-            blob_name = '{}/{}'.format(self.GUID,
+            blob_name = '{}/{}'.format(self.BLOB_PREFIX,
                                        'AccessTestByServiceFabrikPythonLibrary')
             blob = Blob(blob_name, container)
             blob.upload_from_string(

--- a/lib/clients/OpenstackClient.py
+++ b/lib/clients/OpenstackClient.py
@@ -131,7 +131,8 @@ class OpenstackClient(BaseClient):
         try:
             snapshot = self.cinder.volume_snapshots.get(snapshot_id)
             return Snapshot(snapshot.id, snapshot.size, snapshot.created_at, snapshot.status)
-        except:
+        except Exception as error:
+            self.logger.error('[NOVA] Error while getting snapshot with snapshot id {}.\n{}'.format(snapshot_id, error))
             return None
 
 
@@ -139,7 +140,8 @@ class OpenstackClient(BaseClient):
         try:
             volume = self.cinder.volumes.get(volume_id)
             return Volume(volume.id, volume.status, volume.size)
-        except:
+        except Exception as error:
+            self.logger.error('[NOVA] Error while getting volume with id {}.\n{}'.format(volume_id, error))
             return None
 
 
@@ -148,7 +150,8 @@ class OpenstackClient(BaseClient):
             volumes = self.nova.volumes.get_server_volumes(instance_id)
             return [Volume(volume.id, 'none', self.cinder.volumes.get(volume.id).size, volume.device)
                     for volume in volumes]
-        except:
+        except Exception as error:
+            self.logger.error('[NOVA] Error while getting attached volumes for instance {}.\n{}'.format(instance_id, error))
             return []
 
 

--- a/lib/clients/OpenstackClient.py
+++ b/lib/clients/OpenstackClient.py
@@ -132,7 +132,7 @@ class OpenstackClient(BaseClient):
             snapshot = self.cinder.volume_snapshots.get(snapshot_id)
             return Snapshot(snapshot.id, snapshot.size, snapshot.created_at, snapshot.status)
         except Exception as error:
-            self.logger.error('[NOVA] Error while getting snapshot with snapshot id {}.\n{}'.format(snapshot_id, error))
+            self.logger.error('[CINDER] Error while getting snapshot with snapshot id {}.\n{}'.format(snapshot_id, error))
             return None
 
 
@@ -141,7 +141,7 @@ class OpenstackClient(BaseClient):
             volume = self.cinder.volumes.get(volume_id)
             return Volume(volume.id, volume.status, volume.size)
         except Exception as error:
-            self.logger.error('[NOVA] Error while getting volume with id {}.\n{}'.format(volume_id, error))
+            self.logger.error('[CINDER] Error while getting volume with id {}.\n{}'.format(volume_id, error))
             return None
 
 

--- a/lib/clients/OpenstackClient.py
+++ b/lib/clients/OpenstackClient.py
@@ -130,7 +130,7 @@ class OpenstackClient(BaseClient):
     def get_snapshot(self, snapshot_id):
         try:
             snapshot = self.cinder.volume_snapshots.get(snapshot_id)
-            return Snapshot(snapshot.id, snapshot.size, snapshot.status)
+            return Snapshot(snapshot.id, snapshot.size, snapshot.created_at, snapshot.status)
         except:
             return None
 
@@ -181,7 +181,7 @@ class OpenstackClient(BaseClient):
                        None,
                        snapshot)
 
-            snapshot = Snapshot(snapshot.id, snapshot.size, snapshot.status)
+            snapshot = Snapshot(snapshot.id, snapshot.size, snapshot.created_at, snapshot.status)
             self._add_snapshot(snapshot.id)
             self.logger.info('{} SUCCESS: snapshot-id={}, volume-id={}'.format(log_prefix, snapshot.id, volume_id))
         except Exception as error:

--- a/lib/clients/index.py
+++ b/lib/clients/index.py
@@ -13,7 +13,7 @@ iaas_client_max_delay = 600000
 # a random jitter would be added as part of exponential backoff to further minimize conflicts
 iaas_client_jitter = 1000
 
-# total_wait_time = (2 ** attempt) * iaas_client_exp_multiplier + random.random() * iaas_client_jitter milliseconds
+# wait_time_between_attempts = (2 ** attempt) * iaas_client_exp_multiplier + random.random() * iaas_client_jitter milliseconds
 # https://github.com/rholder/retrying/blob/master/retrying.py#L247
 
 @retry(stop_max_attempt_number=iaas_client_max_retries, wait_exponential_multiplier=iaas_client_exp_multiplier, stop_max_delay=iaas_client_max_delay, wait_jitter_max=iaas_client_jitter)

--- a/lib/clients/index.py
+++ b/lib/clients/index.py
@@ -13,6 +13,9 @@ iaas_client_max_delay = 600000
 # a random jitter would be added as part of exponential backoff to further minimize conflicts
 iaas_client_jitter = 1000
 
+# total_wait_time = (2 ** attempt) * iaas_client_exp_multiplier + random.random() * iaas_client_jitter milliseconds
+# https://github.com/rholder/retrying/blob/master/retrying.py#L247
+
 @retry(stop_max_attempt_number=iaas_client_max_retries, wait_exponential_multiplier=iaas_client_exp_multiplier, stop_max_delay=iaas_client_max_delay, wait_jitter_max=iaas_client_jitter)
 def _create_iaas_client(operation_name, configuration, directory_persistent, directory_work_list, poll_delay_time=None,
                        poll_maximum_time=None):

--- a/lib/clients/index.py
+++ b/lib/clients/index.py
@@ -1,9 +1,9 @@
 import sys
+import os
 from retrying import retry
 
 # configurable
-iaas_client_max_retries = 8
-
+iaas_client_max_retries = int(os.getenv('SF_IAAS_CLIENT_MAX_RETRY')) if os.getenv('SF_IAAS_CLIENT_MAX_RETRY') is not None else 8
 # between subsequent attempts, waiting_time = (2 ** attempt) * iaas_client_exp_multiplier milliseconds
 iaas_client_exp_multiplier = 1000
 

--- a/lib/config.py
+++ b/lib/config.py
@@ -100,11 +100,6 @@ def _get_parameters_restore_optional():
 def _get_parameters_blob_operation():
     return merge_dict(parameters, parameters_blob_operation)
 
-def remove_all_files(dir_path):
-    if os.path.exists(dir_path):
-        shutil.rmtree(dir_path)
-        os.makedirs(dir_path)
-
 # this function will remove all the files in the directories pointed by SF_BACKUP_RESTORE_LOG_DIRECTORY
 # and SF_BACKUP_RESTORE_LAST_OPERATION_DIRECTORY
 def remove_old_logs_state():
@@ -115,9 +110,17 @@ def remove_old_logs_state():
     assert directory_logfile is not None, 'SF_BACKUP_RESTORE_LOG_DIRECTORY environment variable is not set.'
     assert directory_last_operation is not None, 'SF_BACKUP_RESTORE_LAST_OPERATION_DIRECTORY environment variable is not set.'
 
-    remove_all_files(directory_logfile)
-    remove_all_files(directory_last_operation)
-    
+    for operation in ['backup', 'restore', 'blob_operation']:   
+        # +-> Define paths for log and last operation file
+        path_log = os.path.join(directory_logfile, operation + '.log')
+        path_blue = os.path.join(directory_last_operation, operation + '.lastoperation.blue.json')
+        path_green = os.path.join(directory_last_operation, operation + '.lastoperation.green.json')
+        
+        # +-> open a new file if it doesn't exist, and truncate if file exists.
+        open(path_log, 'w+').close()
+        open(path_blue, 'w+').close()
+        open(path_green, 'w+').close()
+
 def parse_options(type):
     """Parse the required command line options for the given operation type.
 

--- a/lib/config.py
+++ b/lib/config.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 from argparse import ArgumentParser
 from .utils.merge_dict import merge_dict
 from .logger import init_logger

--- a/lib/config.py
+++ b/lib/config.py
@@ -4,7 +4,7 @@ from .utils.merge_dict import merge_dict
 from .logger import init_logger
 
 parameters = {
-    'iaas': 'the underlying IaaS provider [possible values: aws/azure/gcp/openstack/boshlite]',
+    'iaas': 'the underlying IaaS provider [possible values: aws/azure/gcp/ali/openstack/boshlite]',
     'type': 'online or offline backup [possible values: online/offline]'
 }
 

--- a/lib/config.py
+++ b/lib/config.py
@@ -66,6 +66,8 @@ parameters_restore = {
     'agent_ip': 'IP of the agent VM'
 }
 
+parameters_blob_operation = {}
+
 parameters_restore_optional = {
     'agent_id': 'the agent id',
     'agent_ip': 'IP of the agent VM'
@@ -85,6 +87,9 @@ def _get_parameters_restore():
 
 def _get_parameters_restore_optional():
     return parameters_restore_optional
+
+def _get_parameters_blob_operation():
+    return parameters_blob_operation
 
 def parse_options(type):
     """Parse the required command line options for the given operation type.
@@ -109,6 +114,10 @@ def parse_options(type):
             	parser.add_argument('--{}'.format(name), help=description, required=False)
             else:
                 parser.add_argument('--{}'.format(name), help=description, required=True)
+    elif type == 'blob_operation':
+        for name, description in _get_parameters_blob_operation().items():
+            parser.add_argument('--{}'.format(name),
+                                help=description, required=True)
     else:
         raise Exception('Use either \'backup\' or \'restore\' as type.')
 

--- a/lib/config.py
+++ b/lib/config.py
@@ -81,7 +81,6 @@ parameters_restore_optional = {
     'agent_ip': 'IP of the agent VM'
 }
 
-
 def _get_parameters_credentials():
     return parameters_credentials
 
@@ -122,7 +121,7 @@ def remove_old_logs_state():
         open(path_green, 'w+').close()
         open(path_output_json, 'w+').close()
 
-def build_parser():
+def build_parser(type):
     # TODO: conflict_handler='resolve' is really required ??
     parser = ArgumentParser(conflict_handler='resolve')
     if type == 'backup':
@@ -163,7 +162,7 @@ def parse_options(type):
     # first, remove all the old logs and data
     remove_old_logs_state()
 
-    parser = build_parser()    
+    parser = build_parser(type)    
     
     configuration = vars(parser.parse_args())
     assert configuration['type'] == 'online' or configuration['type'] == 'offline', \

--- a/lib/config.py
+++ b/lib/config.py
@@ -66,7 +66,9 @@ parameters_restore = {
     'agent_ip': 'IP of the agent VM'
 }
 
-parameters_blob_operation = {}
+parameters_blob_operation = {
+    'container': 'a container in the object storage from which to restore data'
+}
 
 parameters_restore_optional = {
     'agent_id': 'the agent id',
@@ -89,7 +91,7 @@ def _get_parameters_restore_optional():
     return parameters_restore_optional
 
 def _get_parameters_blob_operation():
-    return parameters_blob_operation
+    return merge_dict(parameters, parameters_blob_operation)
 
 def parse_options(type):
     """Parse the required command line options for the given operation type.
@@ -140,7 +142,7 @@ def initialize(operation_name):
     assert directory_last_operation is not None, 'SF_BACKUP_RESTORE_LAST_OPERATION_DIRECTORY environment variable is ' \
                                                  'not set.'
 
-    for operation in ['backup', 'restore']:
+    for operation in ['backup', 'restore', 'blob_operation']:
         # +-> Define paths for log and last operation file
         path_log = os.path.join(directory_logfile, operation + '.log')
         path_blue = os.path.join(

--- a/lib/config.py
+++ b/lib/config.py
@@ -18,7 +18,8 @@ parameters_credentials = {
     'ali': {
         'access_key_id': 'Ali Access Key ID',
         'secret_access_key': 'Ali Secret Access Key',
-        'region_name': 'Ali Region Name'
+        'region_name': 'Ali Region Name',
+        'endpoint': 'Ali Endpoint name'
     },
     'azure': {
         'subscription_id': 'Azure subscription id',

--- a/lib/config.py
+++ b/lib/config.py
@@ -98,9 +98,11 @@ def _get_parameters_restore_optional():
 def _get_parameters_blob_operation():
     return merge_dict(parameters, parameters_blob_operation)
 
-# this function will remove all the files in the directories pointed by SF_BACKUP_RESTORE_LOG_DIRECTORY
-# and SF_BACKUP_RESTORE_LAST_OPERATION_DIRECTORY
 def remove_old_logs_state():
+    """
+    Remove all the files in the directories pointed by SF_BACKUP_RESTORE_LOG_DIRECTORY
+    and SF_BACKUP_RESTORE_LAST_OPERATION_DIRECTORY
+    """
     directory_logfile = os.getenv('SF_BACKUP_RESTORE_LOG_DIRECTORY')
     directory_last_operation = os.getenv('SF_BACKUP_RESTORE_LAST_OPERATION_DIRECTORY')
 
@@ -108,7 +110,7 @@ def remove_old_logs_state():
     assert directory_logfile is not None, 'SF_BACKUP_RESTORE_LOG_DIRECTORY environment variable is not set.'
     assert directory_last_operation is not None, 'SF_BACKUP_RESTORE_LAST_OPERATION_DIRECTORY environment variable is not set.'
 
-    for operation in ['backup', 'restore', 'blob_operation']:   
+    for operation in ['backup', 'restore']:   
         # +-> Define paths for log and last operation file
         path_log = os.path.join(directory_logfile, operation + '.log')
         path_blue = os.path.join(directory_last_operation, operation + '.lastoperation.blue.json')

--- a/lib/config.py
+++ b/lib/config.py
@@ -134,36 +134,34 @@ def parse_options(type):
 
 def initialize(operation_name):
     directory_logfile = os.getenv('SF_BACKUP_RESTORE_LOG_DIRECTORY')
-    if operation_name != 'blob_operation':
-        directory_last_operation = os.getenv(
-            'SF_BACKUP_RESTORE_LAST_OPERATION_DIRECTORY')
-        assert directory_last_operation is not None, 'SF_BACKUP_RESTORE_LAST_OPERATION_DIRECTORY environment variable is ' \
-                                                 'not set.'
+    directory_last_operation = os.getenv(
+        'SF_BACKUP_RESTORE_LAST_OPERATION_DIRECTORY')
+
     # Verify that the required environment variables are provided
     assert directory_logfile is not None, 'SF_BACKUP_RESTORE_LOG_DIRECTORY environment variable is not set.'
-    
+    assert directory_last_operation is not None, 'SF_BACKUP_RESTORE_LAST_OPERATION_DIRECTORY environment variable is ' \
+                                                 'not set.'
 
     for operation in ['backup', 'restore', 'blob_operation']:
         # +-> Define paths for log and last operation file
         path_log = os.path.join(directory_logfile, operation + '.log')
-        if operation != 'blob_operation':
-            path_blue = os.path.join(
-                directory_last_operation, operation + '.lastoperation.blue.json')
-            path_green = os.path.join(
-                directory_last_operation, operation + '.lastoperation.green.json')
-            path_link = os.path.join(
-                directory_last_operation, operation + '.lastoperation.json')
-            # +-> Create .log file if it does not exist
-            if not os.path.exists(path_log):
-                open(path_log, 'w+').close()
-            # +-> Create last operation blue/green files if they do not exist
-            if not os.path.exists(path_blue):
-                open(path_blue, 'w+').close()
-            if not os.path.exists(path_green):
-                open(path_green, 'w+').close()
-            # +-> Create symlink to blue file and clear old log entries
-            if operation == operation_name:
-                os.system('ln -sf {} {}'.format(path_blue, path_link))
-                open(path_log, 'w+').close()
+        path_blue = os.path.join(
+            directory_last_operation, operation + '.lastoperation.blue.json')
+        path_green = os.path.join(
+            directory_last_operation, operation + '.lastoperation.green.json')
+        path_link = os.path.join(
+            directory_last_operation, operation + '.lastoperation.json')
+        # +-> Create .log file if it does not exist
+        if not os.path.exists(path_log):
+            open(path_log, 'w+').close()
+        # +-> Create last operation blue/green files if they do not exist
+        if not os.path.exists(path_blue):
+            open(path_blue, 'w+').close()
+        if not os.path.exists(path_green):
+            open(path_green, 'w+').close()
+        # +-> Create symlink to blue file and clear old log entries
+        if operation == operation_name:
+            os.system('ln -sf {} {}'.format(path_blue, path_link))
+            open(path_log, 'w+').close()
 
     init_logger(os.path.join(directory_logfile, operation_name + '.log'))

--- a/lib/config.py
+++ b/lib/config.py
@@ -134,34 +134,36 @@ def parse_options(type):
 
 def initialize(operation_name):
     directory_logfile = os.getenv('SF_BACKUP_RESTORE_LOG_DIRECTORY')
-    directory_last_operation = os.getenv(
-        'SF_BACKUP_RESTORE_LAST_OPERATION_DIRECTORY')
-
+    if operation_name != 'blob_operation':
+        directory_last_operation = os.getenv(
+            'SF_BACKUP_RESTORE_LAST_OPERATION_DIRECTORY')
+        assert directory_last_operation is not None, 'SF_BACKUP_RESTORE_LAST_OPERATION_DIRECTORY environment variable is ' \
+                                                 'not set.'
     # Verify that the required environment variables are provided
     assert directory_logfile is not None, 'SF_BACKUP_RESTORE_LOG_DIRECTORY environment variable is not set.'
-    assert directory_last_operation is not None, 'SF_BACKUP_RESTORE_LAST_OPERATION_DIRECTORY environment variable is ' \
-                                                 'not set.'
+    
 
     for operation in ['backup', 'restore', 'blob_operation']:
         # +-> Define paths for log and last operation file
         path_log = os.path.join(directory_logfile, operation + '.log')
-        path_blue = os.path.join(
-            directory_last_operation, operation + '.lastoperation.blue.json')
-        path_green = os.path.join(
-            directory_last_operation, operation + '.lastoperation.green.json')
-        path_link = os.path.join(
-            directory_last_operation, operation + '.lastoperation.json')
-        # +-> Create .log file if it does not exist
-        if not os.path.exists(path_log):
-            open(path_log, 'w+').close()
-        # +-> Create last operation blue/green files if they do not exist
-        if not os.path.exists(path_blue):
-            open(path_blue, 'w+').close()
-        if not os.path.exists(path_green):
-            open(path_green, 'w+').close()
-        # +-> Create symlink to blue file and clear old log entries
-        if operation == operation_name:
-            os.system('ln -sf {} {}'.format(path_blue, path_link))
-            open(path_log, 'w+').close()
+        if operation != 'blob_operation':
+            path_blue = os.path.join(
+                directory_last_operation, operation + '.lastoperation.blue.json')
+            path_green = os.path.join(
+                directory_last_operation, operation + '.lastoperation.green.json')
+            path_link = os.path.join(
+                directory_last_operation, operation + '.lastoperation.json')
+            # +-> Create .log file if it does not exist
+            if not os.path.exists(path_log):
+                open(path_log, 'w+').close()
+            # +-> Create last operation blue/green files if they do not exist
+            if not os.path.exists(path_blue):
+                open(path_blue, 'w+').close()
+            if not os.path.exists(path_green):
+                open(path_green, 'w+').close()
+            # +-> Create symlink to blue file and clear old log entries
+            if operation == operation_name:
+                os.system('ln -sf {} {}'.format(path_blue, path_link))
+                open(path_log, 'w+').close()
 
     init_logger(os.path.join(directory_logfile, operation_name + '.log'))

--- a/lib/config.py
+++ b/lib/config.py
@@ -15,6 +15,11 @@ parameters_credentials = {
         'region_name': 'AWS Region Name',
         'max_retries': 'Max number of retries for SDK AWS client'
     },
+    'ali': {
+        'access_key_id': 'Ali Access Key ID',
+        'secret_access_key': 'Ali Secret Access Key',
+        'region_name': 'Ali Region Name'
+    },
     'azure': {
         'subscription_id': 'Azure subscription id',
         'resource_group': 'Azure resource group name in subscription',

--- a/lib/config.py
+++ b/lib/config.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 from argparse import ArgumentParser
 from .utils.merge_dict import merge_dict
 from .logger import init_logger
@@ -99,6 +100,24 @@ def _get_parameters_restore_optional():
 def _get_parameters_blob_operation():
     return merge_dict(parameters, parameters_blob_operation)
 
+def remove_all_files(dir_path):
+    if os.path.exists(dir_path):
+        shutil.rmtree(dir_path)
+        os.makedirs(dir_path)
+
+# this function will remove all the files in the directories pointed by SF_BACKUP_RESTORE_LOG_DIRECTORY
+# and SF_BACKUP_RESTORE_LAST_OPERATION_DIRECTORY
+def remove_old_logs_state():
+    directory_logfile = os.getenv('SF_BACKUP_RESTORE_LOG_DIRECTORY')
+    directory_last_operation = os.getenv('SF_BACKUP_RESTORE_LAST_OPERATION_DIRECTORY')
+
+    # Verify that the required environment variables are provided
+    assert directory_logfile is not None, 'SF_BACKUP_RESTORE_LOG_DIRECTORY environment variable is not set.'
+    assert directory_last_operation is not None, 'SF_BACKUP_RESTORE_LAST_OPERATION_DIRECTORY environment variable is not set.'
+
+    remove_all_files(directory_logfile)
+    remove_all_files(directory_last_operation)
+    
 def parse_options(type):
     """Parse the required command line options for the given operation type.
 
@@ -110,6 +129,10 @@ def parse_options(type):
 
             configuration = parse_options('backup')
     """
+
+    # first, remove all the old logs and data
+    remove_old_logs_state()
+
     # TODO: conflict_handler='resolve' is really required ??
     parser = ArgumentParser(conflict_handler='resolve')
     if type == 'backup':

--- a/lib/config.py
+++ b/lib/config.py
@@ -114,27 +114,15 @@ def remove_old_logs_state():
         path_log = os.path.join(directory_logfile, operation + '.log')
         path_blue = os.path.join(directory_last_operation, operation + '.lastoperation.blue.json')
         path_green = os.path.join(directory_last_operation, operation + '.lastoperation.green.json')
+        path_output_json = os.path.join(directory_logfile, operation + '.output.json')
         
         # +-> open a new file if it doesn't exist, and truncate if file exists.
         open(path_log, 'w+').close()
         open(path_blue, 'w+').close()
         open(path_green, 'w+').close()
+        open(path_output_json, 'w+').close()
 
-def parse_options(type):
-    """Parse the required command line options for the given operation type.
-
-    :param type: a string containing either `backup` or `restore`
-    :returns: a dictionary containing the key-value pairs of the provided parameters
-
-    :Example:
-        ::
-
-            configuration = parse_options('backup')
-    """
-
-    # first, remove all the old logs and data
-    remove_old_logs_state()
-
+def build_parser():
     # TODO: conflict_handler='resolve' is really required ??
     parser = ArgumentParser(conflict_handler='resolve')
     if type == 'backup':
@@ -157,6 +145,26 @@ def parse_options(type):
     for key, credentials in _get_parameters_credentials().items():
         for name, description in credentials.items():
             parser.add_argument('--{}'.format(name), help=description)
+
+    return parser
+
+def parse_options(type):
+    """Parse the required command line options for the given operation type.
+
+    :param type: a string containing either `backup` or `restore`
+    :returns: a dictionary containing the key-value pairs of the provided parameters
+
+    :Example:
+        ::
+
+            configuration = parse_options('backup')
+    """
+
+    # first, remove all the old logs and data
+    remove_old_logs_state()
+
+    parser = build_parser()    
+    
     configuration = vars(parser.parse_args())
     assert configuration['type'] == 'online' or configuration['type'] == 'offline', \
         '--type must be \'online\' or \'offline\''

--- a/lib/models/Snapshot.py
+++ b/lib/models/Snapshot.py
@@ -1,5 +1,6 @@
 class Snapshot:
-    def __init__(self, id, size, status):
+    def __init__(self, id, size, start_time, status):
         self.id = id
         self.size = size
+        self.start_time = start_time
         self.status = status

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ google-auth-httplib2==0.0.3
 google-cloud-storage==1.6.0
 iso8601==0.1.12
 pytz==2018.5
+oss2==2.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,5 @@ google-auth==1.2.1
 google-api-python-client==1.6.4
 google-auth-httplib2==0.0.3
 google-cloud-storage==1.6.0
+iso8601==0.1.12
+pytz==2018.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 boto3>=1.4.0, <1.5
-python-keystoneclient>=3.2.0, <3.3
+python-keystoneclient==3.18.0
 python-novaclient>=5.0.0, <5.1
 python-cinderclient>=1.8.0, <1.9
 python-swiftclient>=3.0.0, <3.1

--- a/tests/data/ali/bucket.put.nosuchbucket.json
+++ b/tests/data/ali/bucket.put.nosuchbucket.json
@@ -1,0 +1,23 @@
+{
+    "Error": 
+    {
+        "BucketName": "invalid-container",
+        "Code": "NoSuchBucket",
+        "Message": "The specified bucket does not exist"
+    },
+    "ResponseMetadata": 
+    {
+        "HTTPHeaders": {
+        "content-type": "application/xml",
+        "date": "dummy",
+        "server": "Aliyun",
+        "transfer-encoding": "chunked",
+        "x-amz-id-2": "dummy",
+        "x-amz-request-id": "dummy"
+        },
+        "HTTPStatusCode": 404,
+        "HostId": "dummy",
+        "RequestId": "dummy",
+        "RetryAttempts": 0
+    }
+}

--- a/tests/data/aws/bucket.put.nosuchbucket.json
+++ b/tests/data/aws/bucket.put.nosuchbucket.json
@@ -1,0 +1,23 @@
+{
+    "Error": 
+    {
+        "BucketName": "invalid-container",
+        "Code": "NoSuchBucket",
+        "Message": "The specified bucket does not exist"
+    },
+    "ResponseMetadata": 
+    {
+        "HTTPHeaders": {
+        "content-type": "application/xml",
+        "date": "dummy",
+        "server": "AmazonS3",
+        "transfer-encoding": "chunked",
+        "x-amz-id-2": "dummy",
+        "x-amz-request-id": "dummy"
+        },
+        "HTTPStatusCode": 404,
+        "HostId": "dummy",
+        "RequestId": "dummy",
+        "RetryAttempts": 0
+    }
+}

--- a/tests/data/aws/instance.init.json
+++ b/tests/data/aws/instance.init.json
@@ -1,0 +1,11 @@
+{
+    "id": "vm-id",
+    "placement": {
+        "AvailabilityZone": "abc"
+    },
+    "volumes_list":[
+        {
+            "id": "valid-volume-1"
+        }
+    ]
+}

--- a/tests/data/aws/snapshot.init.json
+++ b/tests/data/aws/snapshot.init.json
@@ -1,0 +1,5 @@
+{
+    "id": "valid-snapshot",
+    "volume_size": 40,
+    "state": "READY"
+}

--- a/tests/data/aws/volumes.init.json
+++ b/tests/data/aws/volumes.init.json
@@ -1,0 +1,18 @@
+{
+    "valid-volume": {
+        "id": "valid-volume",
+        "size": 40,
+        "state": "READY"
+    },
+    "valid-volume-1": {
+        "id": "valid-volume-1",
+        "size": 60,
+        "state": "READY",
+        "attachments":[
+            {
+                "VolumeId":"valid-volume-1",
+                "Device":"/dev/sda"
+            }
+        ]
+    }
+}

--- a/tests/test_clients_AliClient.py
+++ b/tests/test_clients_AliClient.py
@@ -5,7 +5,7 @@ from lib.clients.BaseClient import BaseClient
 
 import oss2
 import os
-
+import pytest
 
 #Test data
 valid_container = 'backup-container'
@@ -47,6 +47,16 @@ class OssDummy:
         def __init__(self, name):
             self.name = name
 
+        def put_object(self,Key):
+            if self.name == valid_container:
+                return
+            else:
+                auth = oss2.Auth(configuration['access_key_id'], configuration['secret_access_key'])
+                client = oss2.Bucket(auth, configuration['endpoint'], self.name)
+                response = json.load(open('tests/data/aws/bucket.put.nosuchbucket.json'))
+                exception = client.exceptions.NoSuchBucket(error_response=response,operation_name='PutObject')
+                raise exception
+
 class AliSessionDummy:
     def __init__(self):
         pass
@@ -84,3 +94,8 @@ class TestAwsClient:
 
     def test_create_aws_client(self):
        assert isinstance(self.testAliClient.container, OssDummy.Bucket)
+
+    def test_get_container_exception(self):
+       with pytest.raises(Exception):
+            container = self.testAliClient.OssDummy.Bucket(invalid_container)
+            assert container is None

--- a/tests/test_clients_AliClient.py
+++ b/tests/test_clients_AliClient.py
@@ -72,7 +72,7 @@ class AliSessionDummy:
 def get_dummy_ali_session():
     return AliSessionDummy()
 
-def get_dummy_container(auth, configuration):
+def get_dummy_container(auth, endpoint):
     return OssDummy.Bucket(configuration['container'])
 
 class TestAwsClient:

--- a/tests/test_clients_AliClient.py
+++ b/tests/test_clients_AliClient.py
@@ -1,0 +1,86 @@
+from tests.utils.utilities import create_start_patcher, stop_all_patchers
+
+from lib.clients.AliClient import AliClient
+from lib.clients.BaseClient import BaseClient
+
+import oss2
+import os
+
+
+#Test data
+valid_container = 'backup-container'
+invalid_container = 'invalid-container'
+
+configuration = {
+    'credhub_url' : None,
+    'type' : 'online',
+    'backup_guid' : 'backup-guid',
+    'instance_id' : 'vm-id',
+    'secret' : 'xyz',
+    'job_name' : 'service-job-name',
+    'container' : valid_container,
+    'access_key_id' : 'key-id',
+    'secret_access_key' : 'secret-key',
+    'endpoint': 'endpoint-name',
+    'region_name' : 'xyz'
+}
+
+directory_persistent = '/var/vcap/store'
+directory_work_list = '/tmp'
+log_dir = 'tests'
+poll_delay_time = 10
+poll_maximum_time = 60
+
+operation_name = 'backup'
+
+def mock_shell(command):
+    print(command)
+    if command == ('cat /proc/mounts | grep '+ directory_persistent):
+        return valid_volume_device
+
+class OssClientDummy:
+    def __init__(self):
+        pass
+
+class OssDummy:
+    class Bucket:
+        def __init__(self, name):
+            self.name = name
+
+class AliSessionDummy:
+    def __init__(self):
+        pass
+
+    def resource(self, type, config=None):
+        if type == 'oss':
+            return OssDummy()
+
+    def client(self, type, config=None):
+        if type == 's3':
+            return OssClientDummy()
+
+def get_dummy_ali_session():
+    return AliSessionDummy()
+
+def get_dummy_container(auth, configuration):
+    return OssDummy.Bucket(configuration['container'])
+
+class TestAwsClient:
+    patchers = []
+    @classmethod
+    def setup_class(self):
+        #self.patchers.append(create_start_patcher(patch_function='__init__',patch_object=AliClient,side_effect=get_dummy_ali_session)['patcher'])
+        self.patchers.append(create_start_patcher(patch_function='get_container',patch_object=AliClient,side_effect=get_dummy_container)['patcher'])
+        self.patchers.append(create_start_patcher(patch_function='last_operation', patch_object=BaseClient)['patcher'])
+        self.patchers.append(create_start_patcher(patch_function='shell', patch_object=BaseClient, side_effect=mock_shell)['patcher'])
+        os.environ['SF_BACKUP_RESTORE_LOG_DIRECTORY'] = log_dir
+        os.environ['SF_BACKUP_RESTORE_LAST_OPERATION_DIRECTORY'] = log_dir
+
+        self.testAliClient = AliClient(operation_name, configuration, directory_persistent, directory_work_list,poll_delay_time, poll_maximum_time)
+
+    @classmethod
+    def teardown_class(self):
+        stop_all_patchers(self.patchers)
+
+    def test_create_aws_client(self):
+       assert isinstance(self.testAliClient.container, OssDummy.Bucket)

--- a/tests/test_clients_AwsClient.py
+++ b/tests/test_clients_AwsClient.py
@@ -187,7 +187,6 @@ class TestAwsClient:
         assert isinstance(self.testAwsClient.ec2.client, EC2ClientDummy)
         assert isinstance(self.testAwsClient.s3.client, S3ClientDummy)
         assert self.testAwsClient.availability_zone == availability_zone
-<<<<<<< HEAD
 
     def test_create_aws_client_blob_ops(self):
         assert isinstance(self.testAwsClientBlobOps.s3, S3Dummy)
@@ -199,9 +198,3 @@ class TestAwsClient:
         with pytest.raises(Exception):
             container = self.testAwsClient.s3.Bucket(invalid_container)
             assert container is None
-<<<<<<< HEAD
-
-=======
->>>>>>> Added initial UT framework for AwsClient
-=======
->>>>>>> Adding and modifying UTs

--- a/tests/test_clients_AwsClient.py
+++ b/tests/test_clients_AwsClient.py
@@ -37,16 +37,24 @@ configuration = {
     'region_name' : 'xyz'
 }
 
+configuration_blob_ops = {
+    'credhub_url' : None,
+    'type' : 'online',
+    'container' : valid_container,
+    'access_key_id' : 'key-id',
+    'secret_access_key' : 'secret-key',
+    'region_name' : 'xyz'
+}
+
 directory_persistent = '/var/vcap/store'
 directory_work_list = '/tmp'
 log_dir = 'tests'
 poll_delay_time = 10
 poll_maximum_time = 60
 operation_name = 'backup'
+operation_name_blob_ops = 'blob_operation'
 availability_zone = 'abc'
 
-<<<<<<< HEAD
-=======
 #helper functions
 def loadJsonToObject(path, object):
     response = json.load(open(path))
@@ -63,7 +71,6 @@ def mock_shell(command):
     if command == ('cat /proc/mounts | grep '+ directory_persistent):
         return valid_volume_device
 
->>>>>>> Added initial UT framework for AwsClient
 # Defintions of dummy clients and resources.
 # More details to be added as new tests will be added 
 class Ec2ConfigDummy:
@@ -71,13 +78,6 @@ class Ec2ConfigDummy:
         pass
 
 class Ec2Dummy:
-<<<<<<< HEAD
-    class Instance:
-        def __init__(self,instance_id):
-            self.instance_id = instance_id
-            self.placement = {}
-            self.placement['AvailabilityZone'] = 'abc'
-=======
     class Snapshot:
         def __init__(self,snapshot_id):
             if snapshot_id != valid_snapshot:
@@ -96,7 +96,6 @@ class Ec2Dummy:
         def __init__(self,instance_id):
             loadJsonToObject('tests/data/aws/instance.init.json', self)
             self.volumes = CollectionsDummy([Ec2Dummy.Volume(v['id']) for v in self.volumes_list])
->>>>>>> Added initial UT framework for AwsClient
 
         def load(self):
             pass
@@ -108,17 +107,11 @@ class EC2ClientDummy:
 class S3Dummy:
     class Bucket:
         def __init__(self, name):
-<<<<<<< HEAD
             if name ==valid_container:
                 self.name = name
                 return
             else:
                 raise Exception('Container not found')
-
-        def put_object(self,Key):
-            pass
-=======
-            self.name = name
 
         def put_object(self,Key):
             if self.name == valid_container:
@@ -128,7 +121,6 @@ class S3Dummy:
                 response = json.load(open('tests/data/aws/bucket.put.nosuchbucket.json'))
                 exception = client.exceptions.NoSuchBucket(error_response=response,operation_name='PutObject')
                 raise exception
->>>>>>> Added initial UT framework for AwsClient
 
         def delete_objects(self,Delete):
             pass
@@ -157,8 +149,6 @@ class AwsSessionDummy:
 def get_dummy_aws_session():
     return AwsSessionDummy()
 
-<<<<<<< HEAD
-=======
 # EC2 instance objects have 'collection' of volumes. Collcetion is boto specific data structure
 # and exposes it's own methods (https://boto3.readthedocs.io/en/latest/guide/collections.html#guide-collections).
 # Hence we need to have it's mocked version also.
@@ -169,7 +159,6 @@ class CollectionsDummy:
     def all(self):
         return self.objects
 
->>>>>>> Added initial UT framework for AwsClient
 def create_start_patcher(patch_function, patch_object=None, return_value=None, side_effect=None):
     if patch_object != None:
         patcher = patch.object(patch_object, patch_function)
@@ -196,15 +185,12 @@ class TestAwsClient:
     def setup_class(self):
         self.patchers.append(create_start_patcher(patch_function='create_aws_session',patch_object=AwsClient,side_effect=get_dummy_aws_session))
         self.patchers.append(create_start_patcher(patch_function='last_operation', patch_object=BaseClient))
-<<<<<<< HEAD
-
-=======
         self.patchers.append(create_start_patcher(patch_function='shell', patch_object=BaseClient, side_effect=mock_shell))
->>>>>>> Added initial UT framework for AwsClient
         os.environ['SF_BACKUP_RESTORE_LOG_DIRECTORY'] = log_dir
         os.environ['SF_BACKUP_RESTORE_LAST_OPERATION_DIRECTORY'] = log_dir
 
         self.testAwsClient = AwsClient(operation_name, configuration, directory_persistent, directory_work_list,poll_delay_time, poll_maximum_time)
+        self.testAwsClientBlobOps = AwsClient(operation_name_blob_ops, configuration_blob_ops, directory_persistent, directory_work_list,poll_delay_time, poll_maximum_time)
 
     @classmethod
     def teardown_class(self):
@@ -213,15 +199,26 @@ class TestAwsClient:
     def test_create_aws_client(self):
         assert isinstance(self.testAwsClient.ec2, Ec2Dummy)
         assert isinstance(self.testAwsClient.s3, S3Dummy)
+        assert hasattr(self.testAwsClient, 'ec2')
+        assert hasattr(self.testAwsClient, 'availability_zone')
         assert isinstance(self.testAwsClient.ec2.client, EC2ClientDummy)
         assert isinstance(self.testAwsClient.s3.client, S3ClientDummy)
         assert self.testAwsClient.availability_zone == availability_zone
 <<<<<<< HEAD
 
+    def test_create_aws_client_blob_ops(self):
+        assert isinstance(self.testAwsClientBlobOps.s3, S3Dummy)
+        assert isinstance(self.testAwsClientBlobOps.s3.client, S3ClientDummy)
+        assert not hasattr(self.testAwsClientBlobOps, 'ec2')
+        assert not hasattr(self.testAwsClientBlobOps, 'availability_zone')
+
     def test_get_container_exception(self):
         with pytest.raises(Exception):
             container = self.testAwsClient.s3.Bucket(invalid_container)
             assert container is None
+<<<<<<< HEAD
 
 =======
 >>>>>>> Added initial UT framework for AwsClient
+=======
+>>>>>>> Adding and modifying UTs

--- a/tests/test_clients_AwsClient.py
+++ b/tests/test_clients_AwsClient.py
@@ -1,3 +1,5 @@
+from tests.utils.utilities import create_start_patcher, stop_all_patchers
+import tests.utils.setup_constants
 import os
 import pytest
 from unittest.mock import patch
@@ -159,33 +161,14 @@ class CollectionsDummy:
     def all(self):
         return self.objects
 
-def create_start_patcher(patch_function, patch_object=None, return_value=None, side_effect=None):
-    if patch_object != None:
-        patcher = patch.object(patch_object, patch_function)
-    else:
-        patcher = patch(patch_function)
-
-    patcher_start = patcher.start()
-    if return_value != None:
-        patcher_start.return_value = return_value
-    
-    if side_effect != None:
-        patcher_start.side_effect = side_effect
-    
-    return patcher
-
-def stop_all_patchers(patchers):
-    for patcher in patchers:
-        patcher.stop()
-
 #Tests
 class TestAwsClient:
     patchers = []
     @classmethod
     def setup_class(self):
-        self.patchers.append(create_start_patcher(patch_function='create_aws_session',patch_object=AwsClient,side_effect=get_dummy_aws_session))
-        self.patchers.append(create_start_patcher(patch_function='last_operation', patch_object=BaseClient))
-        self.patchers.append(create_start_patcher(patch_function='shell', patch_object=BaseClient, side_effect=mock_shell))
+        self.patchers.append(create_start_patcher(patch_function='create_aws_session',patch_object=AwsClient,side_effect=get_dummy_aws_session)['patcher'])
+        self.patchers.append(create_start_patcher(patch_function='last_operation', patch_object=BaseClient)['patcher'])
+        self.patchers.append(create_start_patcher(patch_function='shell', patch_object=BaseClient, side_effect=mock_shell)['patcher'])
         os.environ['SF_BACKUP_RESTORE_LOG_DIRECTORY'] = log_dir
         os.environ['SF_BACKUP_RESTORE_LAST_OPERATION_DIRECTORY'] = log_dir
 

--- a/tests/test_clients_GcpClient.py
+++ b/tests/test_clients_GcpClient.py
@@ -52,6 +52,7 @@ bucket = {
     'etag': 'CAE='
 }
 valid_snapshot_name = 'snapshot-id'
+snapshot_create_time = '2018-04-05T07:21:50.624-07:00'
 not_found_snapshot_name = 'notfound-snapshot-id'
 invalid_snapshot_name = 'invalid-snapshot-id'
 delete_snapshot_name = 'delete-snapshot-id'
@@ -560,10 +561,11 @@ class TestGcpClient:
         self.gcpClient.CONTAINER = valid_container
 
     def test_get_snapshot(self):
-        expected_snapshot = Snapshot(valid_snapshot_name, '40', 'READY')
+        expected_snapshot = Snapshot(valid_snapshot_name, '40', snapshot_create_time, 'READY')
         snapshot = self.gcpClient.get_snapshot(valid_snapshot_name)
         assert expected_snapshot.id == snapshot.id
         assert expected_snapshot.size == snapshot.size
+        assert expected_snapshot.start_time == snapshot.start_time
         assert expected_snapshot.status == snapshot.status
 
     def test_get_snapshot_exception(self):

--- a/tests/test_clients_GcpClient.py
+++ b/tests/test_clients_GcpClient.py
@@ -1,5 +1,6 @@
 import os
 import unittest.mock
+from tests.utils.utilities import create_start_patcher, stop_all_patchers
 import pytest
 import json
 import glob
@@ -481,28 +482,6 @@ def get_device_of_volume(volume_id):
     else:
         return None
 
-
-def create_start_patcher(patch_function, patch_object=None, return_value=None, side_effect=None):
-    if patch_object != None:
-        patcher = patch.object(patch_object, patch_function)
-    else:
-        patcher = patch(patch_function)
-
-    patcher_start = patcher.start()
-    if return_value != None:
-        patcher_start.return_value = return_value
-
-    if side_effect != None:
-        patcher_start.side_effect = side_effect
-
-    return patcher
-
-
-def stop_all_patchers(patchers):
-    for patcher in patchers:
-        patcher.stop()
-
-
 class TestGcpClient:
     # Store all patchers
     patchers = []
@@ -510,33 +489,33 @@ class TestGcpClient:
     @classmethod
     def setup_class(self):
         self.patchers.append(create_start_patcher(
-            patch_function='_get_device_of_volume', patch_object=BaseClient, side_effect=get_device_of_volume))
+            patch_function='_get_device_of_volume', patch_object=BaseClient, side_effect=get_device_of_volume)['patcher'])
         self.patchers.append(create_start_patcher(
-            patch_function='delete_snapshot', patch_object=BaseClient, return_value=True))
+            patch_function='delete_snapshot', patch_object=BaseClient, return_value=True)['patcher'])
         self.patchers.append(create_start_patcher(
-            patch_function='delete_volume', patch_object=BaseClient, return_value=True))
+            patch_function='delete_volume', patch_object=BaseClient, return_value=True)['patcher'])
         self.patchers.append(create_start_patcher(
-            patch_function='glob', patch_object=glob, side_effect=mockglob))
+            patch_function='glob', patch_object=glob, side_effect=mockglob)['patcher'])
         self.patchers.append(create_start_patcher(patch_function='generate_name_by_prefix',
-                                                  patch_object=BaseClient, side_effect=generate_name_by_prefix))
+                                                  patch_object=BaseClient, side_effect=generate_name_by_prefix)['patcher'])
         self.patchers.append(create_start_patcher(
-            patch_function='shell', patch_object=BaseClient, side_effect=shell))
+            patch_function='shell', patch_object=BaseClient, side_effect=shell)['patcher'])
         self.patchers.append(create_start_patcher(
-            patch_function='last_operation', patch_object=BaseClient))
+            patch_function='last_operation', patch_object=BaseClient)['patcher'])
         self.patchers.append(create_start_patcher(
-            patch_function='google.oauth2.service_account.Credentials.from_service_account_info'))
+            patch_function='google.oauth2.service_account.Credentials.from_service_account_info')['patcher'])
         self.patchers.append(create_start_patcher(
-            patch_function='googleapiclient.discovery.build', return_value=ComputeClient()))
+            patch_function='googleapiclient.discovery.build', return_value=ComputeClient())['patcher'])
         self.patchers.append(create_start_patcher(
-            patch_function='google.cloud.storage.Client', return_value=StorageClient()))
+            patch_function='google.cloud.storage.Client', return_value=StorageClient())['patcher'])
         self.patchers.append(create_start_patcher(
-            patch_function='google.cloud.storage.Blob.upload_from_string'))
+            patch_function='google.cloud.storage.Blob.upload_from_string')['patcher'])
         self.patchers.append(create_start_patcher(
-            patch_function='google.cloud.storage.Blob.delete'))
+            patch_function='google.cloud.storage.Blob.delete')['patcher'])
         self.patchers.append(create_start_patcher(
-            patch_function='upload_from_filename', patch_object=Blob, side_effect=upload_from_filename))
+            patch_function='upload_from_filename', patch_object=Blob, side_effect=upload_from_filename)['patcher'])
         self.patchers.append(create_start_patcher(
-            patch_function='download_to_filename', patch_object=Blob, side_effect=download_to_filename))
+            patch_function='download_to_filename', patch_object=Blob, side_effect=download_to_filename)['patcher'])
 
         os.environ['SF_BACKUP_RESTORE_LOG_DIRECTORY'] = log_dir
         os.environ['SF_BACKUP_RESTORE_LAST_OPERATION_DIRECTORY'] = log_dir
@@ -812,11 +791,11 @@ class TestGcpClientExceptions:
     @classmethod
     def setup_class(self):
         self.patchers.append(create_start_patcher(
-            patch_function='google.oauth2.service_account.Credentials.from_service_account_info'))
+            patch_function='google.oauth2.service_account.Credentials.from_service_account_info')['patcher'])
         self.patchers.append(create_start_patcher(
-            patch_function='googleapiclient.discovery.build', return_value=ComputeClient()))
+            patch_function='googleapiclient.discovery.build', return_value=ComputeClient())['patcher'])
         self.patchers.append(create_start_patcher(
-            patch_function='google.cloud.storage.Client', return_value=StorageClient()))
+            patch_function='google.cloud.storage.Client', return_value=StorageClient())['patcher'])
 
     @classmethod
     def teardown_class(self):
@@ -829,9 +808,9 @@ class TestGcpClientExceptions:
 
     def test_gcp_client_raises_availability_zone_exception(self):
         mock_blob_upload_patcher = create_start_patcher(
-            patch_function='google.cloud.storage.Blob.upload_from_string')
+            patch_function='google.cloud.storage.Blob.upload_from_string')['patcher']
         mock_blob_delete_patcher = create_start_patcher(
-            patch_function='google.cloud.storage.Blob.delete')
+            patch_function='google.cloud.storage.Blob.delete')['patcher']
         configuration['instance_id'] = invalid_vm_id
         with pytest.raises(Exception, message='Could not retrieve the availability zone of the instance.'):
             GcpClient(operation_name, configuration, directory_persistent, directory_work_list,

--- a/tests/test_clients_GcpClient.py
+++ b/tests/test_clients_GcpClient.py
@@ -52,7 +52,7 @@ bucket = {
     'etag': 'CAE='
 }
 valid_snapshot_name = 'snapshot-id'
-snapshot_create_time = '2018-04-05T07:21:50.624-07:00'
+snapshot_create_time = '2018-04-05T14:21:50Z'
 not_found_snapshot_name = 'notfound-snapshot-id'
 invalid_snapshot_name = 'invalid-snapshot-id'
 delete_snapshot_name = 'delete-snapshot-id'

--- a/tests/test_clients_OpenstackClient.py
+++ b/tests/test_clients_OpenstackClient.py
@@ -43,6 +43,7 @@ poll_delay_time = 10
 poll_maximum_time = 60
 availability_zone = 'rot_2_1'
 valid_snapshot_name = 'snapshot-id'
+snapshot_create_time = '2018-07-11T11:33:17.000000'
 invalid_snapshot_name = 'invalid-snapshot-id'
 not_found_snapshot_name = 'notfound-snapshot-id'
 delete_snapshot_name = 'delete-snapshot-id'
@@ -215,10 +216,11 @@ class TestOpenstackClient:
         self.osClient.CONTAINER = valid_container
 
     def test_get_snapshot(self):
-        expected_snapshot = Snapshot(valid_snapshot_name, 40, 'available')
+        expected_snapshot = Snapshot(valid_snapshot_name, 40, snapshot_create_time, 'available')
         snapshot = self.osClient.get_snapshot(valid_snapshot_name)
         assert expected_snapshot.id == snapshot.id
         assert expected_snapshot.size == snapshot.size
+        assert expected_snapshot.start_time == snapshot.start_time
         assert expected_snapshot.status == snapshot.status
 
     def test_get_snapshot_exception(self):

--- a/tests/test_clients_OpenstackClient.py
+++ b/tests/test_clients_OpenstackClient.py
@@ -1,6 +1,7 @@
 import os
 import pytest
 import ast
+from tests.utils.utilities import create_start_patcher, stop_all_patchers
 from lib.clients.OpenstackClient import OpenstackClient
 from lib.clients.BaseClient import BaseClient
 from unittest.mock import patch
@@ -146,28 +147,6 @@ def file_to_dict(file_path):
     f.close()
     return ast.literal_eval(text)
 
-
-def create_start_patcher(patch_function, patch_object=None, return_value=None, side_effect=None):
-    if patch_object != None:
-        patcher = patch.object(patch_object, patch_function)
-    else:
-        patcher = patch(patch_function)
-
-    patcher_start = patcher.start()
-    if return_value != None:
-        patcher_start.return_value = return_value
-
-    if side_effect != None:
-        patcher_start.side_effect = side_effect
-
-    return patcher
-
-
-def stop_all_patchers(patchers):
-    for patcher in patchers:
-        patcher.stop()
-
-
 class TestOpenstackClient:
     # Store all patchers
     patchers = []
@@ -175,21 +154,21 @@ class TestOpenstackClient:
     @classmethod
     def setup_class(self):
         self.patchers.append(create_start_patcher(
-            patch_function='last_operation', patch_object=BaseClient))
+            patch_function='last_operation', patch_object=BaseClient)['patcher'])
         self.patchers.append(create_start_patcher(
-            patch_function='keystoneauth1.identity.v3.Password'))
+            patch_function='keystoneauth1.identity.v3.Password')['patcher'])
         self.patchers.append(create_start_patcher(
-            patch_function='keystoneauth1.session.Session'))
+            patch_function='keystoneauth1.session.Session')['patcher'])
         self.patchers.append(create_start_patcher(
-            patch_function='get_project_id', patch_object=KeystoneSession))
+            patch_function='get_project_id', patch_object=KeystoneSession)['patcher'])
         self.patchers.append(create_start_patcher(
-            patch_function='create_cinder_client', patch_object=OpenstackClient, return_value=CinderClient()))
+            patch_function='create_cinder_client', patch_object=OpenstackClient, return_value=CinderClient())['patcher'])
         self.patchers.append(create_start_patcher(
-            patch_function='create_nova_client', patch_object=OpenstackClient, return_value=NovaClient()))
+            patch_function='create_nova_client', patch_object=OpenstackClient, return_value=NovaClient())['patcher'])
         self.patchers.append(create_start_patcher(
-            patch_function='create_swift_client', patch_object=OpenstackClient, return_value=SwiftClient()))
+            patch_function='create_swift_client', patch_object=OpenstackClient, return_value=SwiftClient())['patcher'])
         self.patchers.append(create_start_patcher(
-            patch_function='create_swift_service', patch_object=OpenstackClient, return_value=SwiftService()))
+            patch_function='create_swift_service', patch_object=OpenstackClient, return_value=SwiftService())['patcher'])
 
         os.environ['SF_BACKUP_RESTORE_LOG_DIRECTORY'] = log_dir
         os.environ['SF_BACKUP_RESTORE_LAST_OPERATION_DIRECTORY'] = log_dir

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -159,7 +159,7 @@ class TestConfig():
         
         directory_logfile = os.getenv('SF_BACKUP_RESTORE_LOG_DIRECTORY')
         directory_last_operation = os.getenv('SF_BACKUP_RESTORE_LAST_OPERATION_DIRECTORY')
-        for operation in ['backup', 'restore', 'blob_operation']:   
+        for operation in ['backup', 'restore']:   
             # +-> Define paths for log and last operation file
             path_log = os.path.join(directory_logfile, operation + '.log')
             path_blue = os.path.join(directory_last_operation, operation + '.lastoperation.blue.json')

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,172 @@
+from tests.utils.utilities import create_start_patcher, stop_all_patchers
+import tests.utils.setup_constants
+import os
+import pytest
+import unittest.mock as mock
+import unittest
+from lib.config import build_parser, remove_old_logs_state
+import sys
+
+# test data
+
+default_parameters = {
+    'iaas': 'aws',
+    'type': 'online'
+}
+
+credentials_parameters = {
+    'aws': {
+        'access_key_id': 'secret-key',
+        'secret_access_key': 'secret-access-key',
+        'region_name': 'valid-region-name',
+        'max_retries': 'valid-max-retries'
+    },
+}
+
+ops_parameters = {
+    'backup' : {
+        'backup_guid': 'valid-backup-guid',
+        'instance_id': 'valid-instance-id',
+        'secret': 'valid-secret',
+        'container': 'valid-container-name',
+        'job_name': 'valid-job-name'
+    },
+    'restore': {
+        'backup_guid': 'valid-backup-guid',
+        'instance_id': 'valid-instance-id',
+        'secret': 'valid-secret',
+        'container': 'valid-container-name',
+        'job_name': 'valid-job-name',
+        'agent_id': 'valid-agent-id',
+        'agent_ip': 'valid-agent-ip'
+    },
+
+    'blob_operation': {
+        'container': 'valid-container-name'
+    }
+}
+
+restore_optional_parameters = {
+    'agent_id': 'valid-agent-id',
+    'agent_ip': 'valid-agent-ip'
+}
+
+def create_operation_parameters(operation_name):
+    operation_parameters = []
+
+    # default parameters
+    for key, value in default_parameters.items():
+        operation_parameters.append('--{}'.format(key))
+        operation_parameters.append(value)
+
+    # operation specific parameters
+    op_specific_parameters = ops_parameters[operation_name] #operation_name = 'backup'/'restore'
+    for key, value in op_specific_parameters.items():
+        operation_parameters.append('--{}'.format(key))
+        operation_parameters.append(value)
+
+    # credentials parameters
+    for iaas, credentials in credentials_parameters.items():
+        for key, value in credentials.items():
+            operation_parameters.append('--{}'.format(key))
+            operation_parameters.append(value)
+
+    return operation_parameters
+
+# tests
+class TestConfig():
+    patchers = []
+    @classmethod
+    def setup_class(self):
+        pass
+
+    @classmethod
+    def teardown_class(self):
+        pass
+
+    def test_build_parser_backup(self):
+        #build the parser for backup
+        parser = build_parser('backup')
+
+        #build parameters for backup
+        params = create_operation_parameters('backup')
+
+        #pass these parameters to parser and test configuration
+        configuration = vars(parser.parse_args(params))
+        
+        assert configuration['iaas'] == default_parameters['iaas']
+        assert configuration['type'] == default_parameters['type']
+        
+        assert configuration['access_key_id'] == credentials_parameters['aws']['access_key_id']
+        assert configuration['secret_access_key'] == credentials_parameters['aws']['secret_access_key']
+        assert configuration['region_name'] == credentials_parameters['aws']['region_name']
+        assert configuration['max_retries'] == credentials_parameters['aws']['max_retries'] 
+        assert configuration['backup_guid'] == ops_parameters['backup']['backup_guid']
+        assert configuration['instance_id'] == ops_parameters['backup']['instance_id']
+        assert configuration['secret'] == ops_parameters['backup']['secret']
+        assert configuration['container'] == ops_parameters['backup']['container']
+        assert configuration['job_name'] == ops_parameters['backup']['job_name']
+
+    def test_build_parser_restore(self):
+        #build the parser for restore
+        parser = build_parser('restore')
+
+        #build parameters for restore
+        params = create_operation_parameters('restore')
+
+        #pass these parameters to parser and test configuration
+        configuration = vars(parser.parse_args(params))
+        
+        assert configuration['iaas'] == default_parameters['iaas']
+        assert configuration['type'] == default_parameters['type']
+        
+        assert configuration['access_key_id'] == credentials_parameters['aws']['access_key_id']
+        assert configuration['secret_access_key'] == credentials_parameters['aws']['secret_access_key']
+        assert configuration['region_name'] == credentials_parameters['aws']['region_name']
+        assert configuration['max_retries'] == credentials_parameters['aws']['max_retries']
+        assert configuration['backup_guid'] == ops_parameters['restore']['backup_guid']
+        assert configuration['instance_id'] == ops_parameters['restore']['instance_id']
+        assert configuration['secret'] == ops_parameters['restore']['secret']
+        assert configuration['container'] == ops_parameters['restore']['container']
+        assert configuration['job_name'] == ops_parameters['restore']['job_name']
+        assert configuration['agent_id'] == ops_parameters['restore']['agent_id']
+        assert configuration['agent_ip'] == ops_parameters['restore']['agent_ip']
+
+    def test_build_parser_blob_operation(self):
+        #build the parser for restore
+        parser = build_parser('blob_operation')
+
+        #build parameters for restore
+        params = create_operation_parameters('blob_operation')
+
+        #pass these parameters to parser and test configuration
+        configuration = vars(parser.parse_args(params))
+        
+        assert configuration['iaas'] == default_parameters['iaas']
+        assert configuration['type'] == default_parameters['type']
+
+        assert configuration['container'] == ops_parameters['blob_operation']['container']
+
+    def test_build_parser_exception(self):
+        with pytest.raises(Exception) as e:
+            build_parser('invalid_type')
+            assert e.message == 'Use either \'backup\' or \'restore\' as type.'
+
+    def test_remove_old_logs(self):
+        m = mock.mock_open()
+        with mock.patch('builtins.open', m):
+            remove_old_logs_state()
+        
+        directory_logfile = os.getenv('SF_BACKUP_RESTORE_LOG_DIRECTORY')
+        directory_last_operation = os.getenv('SF_BACKUP_RESTORE_LAST_OPERATION_DIRECTORY')
+        for operation in ['backup', 'restore', 'blob_operation']:   
+            # +-> Define paths for log and last operation file
+            path_log = os.path.join(directory_logfile, operation + '.log')
+            path_blue = os.path.join(directory_last_operation, operation + '.lastoperation.blue.json')
+            path_green = os.path.join(directory_last_operation, operation + '.lastoperation.green.json')
+            path_output_json = os.path.join(directory_logfile, operation + '.output.json')
+
+            m.assert_any_call(path_log, 'w+')
+            m.assert_any_call(path_blue, 'w+')
+            m.assert_any_call(path_green, 'w+')
+            m.assert_any_call(path_output_json, 'w+')

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1,0 +1,92 @@
+from tests.utils.utilities import create_start_patcher, stop_all_patchers
+import tests.utils.setup_constants
+import os
+import pytest
+import unittest.mock as mock
+from lib.clients.AwsClient import AwsClient
+from lib.clients.AzureClient import AzureClient
+from lib.clients.GcpClient import GcpClient
+from lib.clients.OpenstackClient import OpenstackClient
+from lib.clients.index import create_iaas_client
+
+# test data
+class DummyIaasInfo:
+    def __init__(self, iaas_name):
+        self.name = iaas_name
+
+    def title(self):
+        return self.name
+
+configuration_aws = { 
+    'iaas': DummyIaasInfo('Aws')
+}
+
+configuration_azure = { 
+    'iaas': DummyIaasInfo('Azure')
+}
+
+configuration_gcp = { 
+    'iaas': DummyIaasInfo('Gcp')
+}
+
+configuration_openstack = { 
+    'iaas': DummyIaasInfo('Openstack')
+}
+directory_persistent = '/var/vcap/store'
+directory_work_list = '/tmp'
+
+def dummy_iaas_client_constructor(operation_name, configuration, directory_persistent, directory_work_list, poll_delay_time=None,poll_maximum_time=None):
+    if operation_name == 'invalid':
+        raise Exception('Induced exception')
+
+    return None
+
+# tests
+class TestIndex:
+    patchers = []
+    @classmethod
+    def setup_class(self):
+        patches = create_start_patcher(patch_function='__init__', patch_object=AwsClient, side_effect=dummy_iaas_client_constructor)
+        self.awsClientPatch = patches['patcher_start']
+        self.patchers.append(patches['patcher'])
+
+        patches = create_start_patcher(patch_function='__init__', patch_object=AzureClient, side_effect=dummy_iaas_client_constructor)
+        self.azureClientPatch = patches['patcher_start']
+        self.patchers.append(patches['patcher'])
+
+        patches = create_start_patcher(patch_function='__init__', patch_object=GcpClient, side_effect=dummy_iaas_client_constructor)
+        self.gcpClientPatch = patches['patcher_start']
+        self.patchers.append(patches['patcher'])
+
+        patches = create_start_patcher(patch_function='__init__', patch_object=OpenstackClient, side_effect=dummy_iaas_client_constructor)
+        self.openstackClientPatch = patches['patcher_start']
+        self.patchers.append(patches['patcher'])
+
+    @classmethod
+    def teardown_class(self):
+        stop_all_patchers(self.patchers)
+
+    def test_create_iaas_client(self):
+        dummy_iaas_client = create_iaas_client('backup', configuration_aws, directory_persistent, directory_work_list)
+        self.awsClientPatch.assert_called_once()
+
+        dummy_iaas_client = create_iaas_client('backup', configuration_azure, directory_persistent, directory_work_list)
+        self.azureClientPatch.assert_called_once()
+
+        dummy_iaas_client = create_iaas_client('backup', configuration_gcp, directory_persistent, directory_work_list)
+        self.gcpClientPatch.assert_called_once()
+
+        dummy_iaas_client = create_iaas_client('backup', configuration_openstack, directory_persistent, directory_work_list)
+        self.openstackClientPatch.assert_called_once()
+
+    def test_import_error(self):
+        configuration_aws['iaas'] = DummyIaasInfo('NotImplemented')
+        with mock.patch('sys.exit') as mock_sys_exit:
+            dummy_iaas_client = create_iaas_client('backup', configuration_aws, directory_persistent, directory_work_list)
+            mock_sys_exit.assert_called_once()
+        configuration_aws['iaas'] = DummyIaasInfo('Aws')
+
+    def test_exception_in_constructor(self):
+        with mock.patch('sys.exit') as mock_sys_exit:
+            dummy_iaas_client = create_iaas_client('invalid', configuration_aws, directory_persistent, directory_work_list)
+            mock_sys_exit.assert_called_once()

--- a/tests/utils/setup_constants.py
+++ b/tests/utils/setup_constants.py
@@ -2,3 +2,5 @@ import os
 
 #setting environment varibale before importing module 
 os.environ['SF_IAAS_CLIENT_MAX_RETRY'] = '1'
+os.environ['SF_BACKUP_RESTORE_LOG_DIRECTORY'] = 'tests/logs'
+os.environ['SF_BACKUP_RESTORE_LAST_OPERATION_DIRECTORY'] = 'tests/logs'

--- a/tests/utils/setup_constants.py
+++ b/tests/utils/setup_constants.py
@@ -1,0 +1,4 @@
+import os
+
+#setting environment varibale before importing module 
+os.environ['SF_IAAS_CLIENT_MAX_RETRY'] = '1'

--- a/tests/utils/utilities.py
+++ b/tests/utils/utilities.py
@@ -1,0 +1,20 @@
+from unittest.mock import patch
+
+def create_start_patcher(patch_function, patch_object=None, return_value=None, side_effect=None):
+    if patch_object != None:
+        patcher = patch.object(patch_object, patch_function)
+    else:
+        patcher = patch(patch_function)
+
+    patcher_start = patcher.start()
+    if return_value != None:
+        patcher_start.return_value = return_value
+    
+    if side_effect != None:
+        patcher_start.side_effect = side_effect
+    
+    return {'patcher' : patcher, 'patcher_start': patcher_start}
+
+def stop_all_patchers(patchers):
+    for patcher in patchers:
+        patcher.stop()


### PR DESCRIPTION
* Currently logs and other state of the previous backup/restore operation is cleared as part of create_iaas_client operation. However if operation fails before/within create_iaas_client, previous state and logs will still be present and hence external agent will conclude wrong result.
* This PR solves this problem by including this removal of logs in the very first call to library, i.e., inside parse_options operation.
* Apart from this, config.py is refactored for the ease of unit testing and readability. UTs for config.py are also added.