### PR TITLE
Converting the snapshot creation timestamp to UTC for GCP IaaS

### DIFF
--- a/lib/clients/GcpClient.py
+++ b/lib/clients/GcpClient.py
@@ -8,6 +8,8 @@ from ..models.Volume import Volume
 from ..models.Attachment import Attachment
 import json
 import glob
+import iso8601
+import pytz
 
 class GcpClient(BaseClient):
     def __init__(self, operation_name, configuration, directory_persistent, directory_work_list, poll_delay_time,
@@ -115,7 +117,9 @@ class GcpClient(BaseClient):
         try:
             snapshot = self.compute_client.snapshots().get(
                 project=self.project_id, snapshot=snapshot_name).execute()
-            return Snapshot(snapshot['name'], snapshot['diskSizeGb'], snapshot['creationTimestamp'], snapshot['status'])
+            snapshot_creation_time_obj=iso8601.parse_date(snapshot['creationTimestamp'])
+            snapshot_creation_time_utc=snapshot_creation_time_obj.astimezone(pytz.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
+            return Snapshot(snapshot['name'], snapshot['diskSizeGb'], snapshot_creation_time_utc, snapshot['status'])
         except Exception as error:
             message = '[GCP] ERROR: Unable to get snapshot {}.\n{}'.format(
                 snapshot_name, error)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,5 @@ google-auth==1.2.1
 google-api-python-client==1.6.4
 google-auth-httplib2==0.0.3
 google-cloud-storage==1.6.0
+iso8601==0.1.12
+pytz==2018.5

--- a/tests/test_clients_GcpClient.py
+++ b/tests/test_clients_GcpClient.py
@@ -52,7 +52,7 @@ bucket = {
     'etag': 'CAE='
 }
 valid_snapshot_name = 'snapshot-id'
-snapshot_create_time = '2018-04-05T07:21:50.624-07:00'
+snapshot_create_time = '2018-04-05T14:21:50Z'
 not_found_snapshot_name = 'notfound-snapshot-id'
 invalid_snapshot_name = 'invalid-snapshot-id'
 delete_snapshot_name = 'delete-snapshot-id'


### PR DESCRIPTION
The snapshot creation time is returned in RFC3339 format for GCP IaaS.
In this PR, we are modifying the logic to first convert it to UTC format and then return the value.