### PR TITLE
Introduction of AliClient to the BnR lib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "3.5.2"
+  - "3.4.3"
 cache: pip3
 install:
   - pip3 install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 python:
-  - "3.4.3"
+  - "3.5.2"
 cache: pip3
 install:
   - pip3 install -r requirements.txt

--- a/lib/clients/AliClient.py
+++ b/lib/clients/AliClient.py
@@ -10,7 +10,7 @@ class AliClient(BaseClient):
         if configuration['credhub_url'] is None:
             auth = oss2.Auth(configuration['access_key_id'], configuration['secret_access_key'])
             endpoint = configuration['endpoint']
-        else
+        else:
             credentials = self._get_credentials_from_credhub(configuration)
             auth = oss2.Auth(credentials['access_key_id'], credentials['secret_access_key'])
             endpoint = credentials['endpoint']

--- a/lib/clients/AliClient.py
+++ b/lib/clients/AliClient.py
@@ -1,0 +1,63 @@
+import oss2
+
+class AliClient(BaseClient):
+    def __init__(self, operation_name, configuration, directory_persistent, directory_work_list, poll_delay_time,
+                 poll_maximum_time):
+        super(AliClient, self).__init__(operation_name, configuration, directory_persistent, directory_work_list,
+                                        poll_delay_time, poll_maximum_time)
+        auth = oss2.Auth(configuration['access_key_id'], configuration['secret_access_key'])
+        # +-> Check whether the given container exists
+        self.container = self.get_container()
+        if not self.container:
+            msg = 'Could not find or access the given container.'
+            self.last_operation(msg, 'failed')
+            raise Exception(msg)
+
+    def get_container(self):
+        try:
+            container = oss2.Bucket(auth, configuration['endpoint'], self.CONTAINER)
+            # Test if the container is accessible
+            key = '{}/{}'.format(self.BLOB_PREFIX, 'AccessTestByServiceFabrikPythonLibrary')
+            bucket.put_object(key, 'This is a sample text')
+            bucket.delete_object(key)
+            return container
+        except Exception as error:
+            self.logger.error('[OSS] ERROR: Unable to find or access container {}.\n{}'.format(
+                self.CONTAINER, error))
+            return None
+
+    def _upload_to_blobstore(self, blob_to_upload_path, blob_target_name):
+        log_prefix = '[OSS] [UPLOAD]'
+
+        if self.container:
+            self.logger.info(
+                '{} Started to upload the tarball to the object storage.'.format(log_prefix))
+            try:
+                self.container.put_object(
+                    blob_to_upload_path, blob_target_name)
+                self.logger.info('{} SUCCESS: blob_to_upload={}, blob_target_name={}, container={}'
+                                 .format(log_prefix, blob_to_upload_path, blob_target_name, self.CONTAINER))
+                return True
+            except Exception as error:
+                message = '{} ERROR: blob_to_upload={}, blob_target_name={}, container={}\n{}'.format(
+                    log_prefix, blob_to_upload_path, blob_target_name, self.CONTAINER, error)
+                self.logger.error(message)
+                raise Exception(message)
+
+    def _download_from_blobstore(self, blob_to_download_name, blob_download_target_path):
+        log_prefix = '[OSS] [DOWNLOAD]'
+
+        if self.container:
+            self.logger.info('{} Started to download the tarball to target{}.'
+                             .format(log_prefix, blob_download_target_path))
+            try:
+                self.container.get_object(
+                    blob_to_download_name, blob_download_target_path).read()
+                self.logger.info('{} SUCCESS: blob_to_download={}, blob_target_name={}, container={}'.format(
+                    log_prefix, blob_to_download_name, self.CONTAINER, blob_download_target_path))
+                return True
+            except Exception as error:
+                message = '{} ERROR: blob_to_download={}, blob_target_name={}, container={}\n{}'.format(
+                    log_prefix, blob_to_download_name, blob_download_target_path, self.CONTAINER, error)
+                self.logger.error(message)
+                raise Exception(message)

--- a/lib/clients/AliClient.py
+++ b/lib/clients/AliClient.py
@@ -1,4 +1,6 @@
 import oss2
+from oss2.headers import RequestHeader
+from .BaseClient import BaseClient
 
 class AliClient(BaseClient):
     def __init__(self, operation_name, configuration, directory_persistent, directory_work_list, poll_delay_time,
@@ -7,19 +9,19 @@ class AliClient(BaseClient):
                                         poll_delay_time, poll_maximum_time)
         auth = oss2.Auth(configuration['access_key_id'], configuration['secret_access_key'])
         # +-> Check whether the given container exists
-        self.container = self.get_container()
+        self.container = self.get_container(auth, configuration)
         if not self.container:
             msg = 'Could not find or access the given container.'
             self.last_operation(msg, 'failed')
             raise Exception(msg)
 
-    def get_container(self):
+    def get_container(self, auth, configuration):
         try:
             container = oss2.Bucket(auth, configuration['endpoint'], self.CONTAINER)
             # Test if the container is accessible
             key = '{}/{}'.format(self.BLOB_PREFIX, 'AccessTestByServiceFabrikPythonLibrary')
-            bucket.put_object(key, 'This is a sample text')
-            bucket.delete_object(key)
+            container.put_object(key, 'This is a sample text')
+            container.delete_object(key)
             return container
         except Exception as error:
             self.logger.error('[OSS] ERROR: Unable to find or access container {}.\n{}'.format(
@@ -33,8 +35,9 @@ class AliClient(BaseClient):
             self.logger.info(
                 '{} Started to upload the tarball to the object storage.'.format(log_prefix))
             try:
-                self.container.put_object(
-                    blob_to_upload_path, blob_target_name)
+                requestHeader = RequestHeader()
+                requestHeader.set_server_side_encryption("AES256")
+                self.container.put_object_from_file(blob_target_name, blob_to_upload_path, headers=requestHeader)
                 self.logger.info('{} SUCCESS: blob_to_upload={}, blob_target_name={}, container={}'
                                  .format(log_prefix, blob_to_upload_path, blob_target_name, self.CONTAINER))
                 return True
@@ -60,4 +63,4 @@ class AliClient(BaseClient):
                 message = '{} ERROR: blob_to_download={}, blob_target_name={}, container={}\n{}'.format(
                     log_prefix, blob_to_download_name, blob_download_target_path, self.CONTAINER, error)
                 self.logger.error(message)
-                raise Exception(message)
+                raise Exception(message) 

--- a/lib/config.py
+++ b/lib/config.py
@@ -4,7 +4,7 @@ from .utils.merge_dict import merge_dict
 from .logger import init_logger
 
 parameters = {
-    'iaas': 'the underlying IaaS provider [possible values: aws/azure/gcp/openstack/boshlite]',
+    'iaas': 'the underlying IaaS provider [possible values: aws/azure/gcp/ali/openstack/boshlite]',
     'type': 'online or offline backup [possible values: online/offline]'
 }
 

--- a/lib/config.py
+++ b/lib/config.py
@@ -18,7 +18,8 @@ parameters_credentials = {
     'ali': {
         'access_key_id': 'Ali Access Key ID',
         'secret_access_key': 'Ali Secret Access Key',
-        'region_name': 'Ali Region Name'
+        'region_name': 'Ali Region Name',
+        'endpoint': 'Ali Endpoint name'
     },
     'azure': {
         'subscription_id': 'Azure subscription id',

--- a/lib/config.py
+++ b/lib/config.py
@@ -15,6 +15,11 @@ parameters_credentials = {
         'region_name': 'AWS Region Name',
         'max_retries': 'Max number of retries for SDK AWS client'
     },
+    'ali': {
+        'access_key_id': 'Ali Access Key ID',
+        'secret_access_key': 'Ali Secret Access Key',
+        'region_name': 'Ali Region Name'
+    },
     'azure': {
         'subscription_id': 'Azure subscription id',
         'resource_group': 'Azure resource group name in subscription',

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ google-auth-httplib2==0.0.3
 google-cloud-storage==1.6.0
 iso8601==0.1.12
 pytz==2018.5
+oss2==2.6.1

--- a/tests/data/ali/bucket.put.nosuchbucket.json
+++ b/tests/data/ali/bucket.put.nosuchbucket.json
@@ -1,0 +1,23 @@
+{
+    "Error": 
+    {
+        "BucketName": "invalid-container",
+        "Code": "NoSuchBucket",
+        "Message": "The specified bucket does not exist"
+    },
+    "ResponseMetadata": 
+    {
+        "HTTPHeaders": {
+        "content-type": "application/xml",
+        "date": "dummy",
+        "server": "Aliyun",
+        "transfer-encoding": "chunked",
+        "x-amz-id-2": "dummy",
+        "x-amz-request-id": "dummy"
+        },
+        "HTTPStatusCode": 404,
+        "HostId": "dummy",
+        "RequestId": "dummy",
+        "RetryAttempts": 0
+    }
+}

--- a/tests/test_clients_AliClient.py
+++ b/tests/test_clients_AliClient.py
@@ -5,7 +5,7 @@ from lib.clients.BaseClient import BaseClient
 
 import oss2
 import os
-
+import pytest
 
 #Test data
 valid_container = 'backup-container'
@@ -47,6 +47,16 @@ class OssDummy:
         def __init__(self, name):
             self.name = name
 
+        def put_object(self,Key):
+            if self.name == valid_container:
+                return
+            else:
+                auth = oss2.Auth(configuration['access_key_id'], configuration['secret_access_key'])
+                client = oss2.Bucket(auth, configuration['endpoint'], self.name)
+                response = json.load(open('tests/data/aws/bucket.put.nosuchbucket.json'))
+                exception = client.exceptions.NoSuchBucket(error_response=response,operation_name='PutObject')
+                raise exception
+
 class AliSessionDummy:
     def __init__(self):
         pass
@@ -84,3 +94,8 @@ class TestAwsClient:
 
     def test_create_aws_client(self):
        assert isinstance(self.testAliClient.container, OssDummy.Bucket)
+
+    def test_get_container_exception(self):
+       with pytest.raises(Exception):
+            container = self.testAliClient.OssDummy.Bucket(invalid_container)
+            assert container is None

--- a/tests/test_clients_AliClient.py
+++ b/tests/test_clients_AliClient.py
@@ -72,7 +72,7 @@ class AliSessionDummy:
 def get_dummy_ali_session():
     return AliSessionDummy()
 
-def get_dummy_container(auth, configuration):
+def get_dummy_container(auth, endpoint):
     return OssDummy.Bucket(configuration['container'])
 
 class TestAwsClient:

--- a/tests/test_clients_AliClient.py
+++ b/tests/test_clients_AliClient.py
@@ -1,0 +1,86 @@
+from tests.utils.utilities import create_start_patcher, stop_all_patchers
+
+from lib.clients.AliClient import AliClient
+from lib.clients.BaseClient import BaseClient
+
+import oss2
+import os
+
+
+#Test data
+valid_container = 'backup-container'
+invalid_container = 'invalid-container'
+
+configuration = {
+    'credhub_url' : None,
+    'type' : 'online',
+    'backup_guid' : 'backup-guid',
+    'instance_id' : 'vm-id',
+    'secret' : 'xyz',
+    'job_name' : 'service-job-name',
+    'container' : valid_container,
+    'access_key_id' : 'key-id',
+    'secret_access_key' : 'secret-key',
+    'endpoint': 'endpoint-name',
+    'region_name' : 'xyz'
+}
+
+directory_persistent = '/var/vcap/store'
+directory_work_list = '/tmp'
+log_dir = 'tests'
+poll_delay_time = 10
+poll_maximum_time = 60
+
+operation_name = 'backup'
+
+def mock_shell(command):
+    print(command)
+    if command == ('cat /proc/mounts | grep '+ directory_persistent):
+        return valid_volume_device
+
+class OssClientDummy:
+    def __init__(self):
+        pass
+
+class OssDummy:
+    class Bucket:
+        def __init__(self, name):
+            self.name = name
+
+class AliSessionDummy:
+    def __init__(self):
+        pass
+
+    def resource(self, type, config=None):
+        if type == 'oss':
+            return OssDummy()
+
+    def client(self, type, config=None):
+        if type == 's3':
+            return OssClientDummy()
+
+def get_dummy_ali_session():
+    return AliSessionDummy()
+
+def get_dummy_container(auth, configuration):
+    return OssDummy.Bucket(configuration['container'])
+
+class TestAwsClient:
+    patchers = []
+    @classmethod
+    def setup_class(self):
+        #self.patchers.append(create_start_patcher(patch_function='__init__',patch_object=AliClient,side_effect=get_dummy_ali_session)['patcher'])
+        self.patchers.append(create_start_patcher(patch_function='get_container',patch_object=AliClient,side_effect=get_dummy_container)['patcher'])
+        self.patchers.append(create_start_patcher(patch_function='last_operation', patch_object=BaseClient)['patcher'])
+        self.patchers.append(create_start_patcher(patch_function='shell', patch_object=BaseClient, side_effect=mock_shell)['patcher'])
+        os.environ['SF_BACKUP_RESTORE_LOG_DIRECTORY'] = log_dir
+        os.environ['SF_BACKUP_RESTORE_LAST_OPERATION_DIRECTORY'] = log_dir
+
+        self.testAliClient = AliClient(operation_name, configuration, directory_persistent, directory_work_list,poll_delay_time, poll_maximum_time)
+
+    @classmethod
+    def teardown_class(self):
+        stop_all_patchers(self.patchers)
+
+    def test_create_aws_client(self):
+       assert isinstance(self.testAliClient.container, OssDummy.Bucket)


### PR DESCRIPTION
This PR introduces the `AliClient` to the backup-restore library.
This client will be needed to support any backup/restore operations in an `Ali` IaaS.

For now, this client introduces 3 functions: `getContainer`, `_upload_to_blobstore` and `_download_from_blobstore`. 

This will enable taking backups and storing in Object Storage and downloading these objects from ObjectStorage during restore.

This being an iterative change, the snapshot based functions will be introduced later.