### PR TITLE
Exposing new function to clear state (logs and last op) of previous operation

### DIFF
--- a/lib/config.py
+++ b/lib/config.py
@@ -100,11 +100,6 @@ def _get_parameters_restore_optional():
 def _get_parameters_blob_operation():
     return merge_dict(parameters, parameters_blob_operation)
 
-def remove_all_files(dir_path):
-    if os.path.exists(dir_path):
-        shutil.rmtree(dir_path)
-        os.makedirs(dir_path)
-
 # this function will remove all the files in the directories pointed by SF_BACKUP_RESTORE_LOG_DIRECTORY
 # and SF_BACKUP_RESTORE_LAST_OPERATION_DIRECTORY
 def remove_old_logs_state():
@@ -115,9 +110,17 @@ def remove_old_logs_state():
     assert directory_logfile is not None, 'SF_BACKUP_RESTORE_LOG_DIRECTORY environment variable is not set.'
     assert directory_last_operation is not None, 'SF_BACKUP_RESTORE_LAST_OPERATION_DIRECTORY environment variable is not set.'
 
-    remove_all_files(directory_logfile)
-    remove_all_files(directory_last_operation)
-    
+    for operation in ['backup', 'restore', 'blob_operation']:   
+        # +-> Define paths for log and last operation file
+        path_log = os.path.join(directory_logfile, operation + '.log')
+        path_blue = os.path.join(directory_last_operation, operation + '.lastoperation.blue.json')
+        path_green = os.path.join(directory_last_operation, operation + '.lastoperation.green.json')
+        
+        # +-> open a new file if it doesn't exist, and truncate if file exists.
+        open(path_log, 'w+').close()
+        open(path_blue, 'w+').close()
+        open(path_green, 'w+').close()
+
 def parse_options(type):
     """Parse the required command line options for the given operation type.
 

--- a/lib/config.py
+++ b/lib/config.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 from argparse import ArgumentParser
 from .utils.merge_dict import merge_dict
 from .logger import init_logger

--- a/lib/config.py
+++ b/lib/config.py
@@ -81,7 +81,6 @@ parameters_restore_optional = {
     'agent_ip': 'IP of the agent VM'
 }
 
-
 def _get_parameters_credentials():
     return parameters_credentials
 
@@ -122,7 +121,7 @@ def remove_old_logs_state():
         open(path_green, 'w+').close()
         open(path_output_json, 'w+').close()
 
-def build_parser():
+def build_parser(type):
     # TODO: conflict_handler='resolve' is really required ??
     parser = ArgumentParser(conflict_handler='resolve')
     if type == 'backup':
@@ -163,7 +162,7 @@ def parse_options(type):
     # first, remove all the old logs and data
     remove_old_logs_state()
 
-    parser = build_parser()    
+    parser = build_parser(type)    
     
     configuration = vars(parser.parse_args())
     assert configuration['type'] == 'online' or configuration['type'] == 'offline', \

--- a/lib/config.py
+++ b/lib/config.py
@@ -98,9 +98,11 @@ def _get_parameters_restore_optional():
 def _get_parameters_blob_operation():
     return merge_dict(parameters, parameters_blob_operation)
 
-# this function will remove all the files in the directories pointed by SF_BACKUP_RESTORE_LOG_DIRECTORY
-# and SF_BACKUP_RESTORE_LAST_OPERATION_DIRECTORY
 def remove_old_logs_state():
+    """
+    Remove all the files in the directories pointed by SF_BACKUP_RESTORE_LOG_DIRECTORY
+    and SF_BACKUP_RESTORE_LAST_OPERATION_DIRECTORY
+    """
     directory_logfile = os.getenv('SF_BACKUP_RESTORE_LOG_DIRECTORY')
     directory_last_operation = os.getenv('SF_BACKUP_RESTORE_LAST_OPERATION_DIRECTORY')
 
@@ -108,7 +110,7 @@ def remove_old_logs_state():
     assert directory_logfile is not None, 'SF_BACKUP_RESTORE_LOG_DIRECTORY environment variable is not set.'
     assert directory_last_operation is not None, 'SF_BACKUP_RESTORE_LAST_OPERATION_DIRECTORY environment variable is not set.'
 
-    for operation in ['backup', 'restore', 'blob_operation']:   
+    for operation in ['backup', 'restore']:   
         # +-> Define paths for log and last operation file
         path_log = os.path.join(directory_logfile, operation + '.log')
         path_blue = os.path.join(directory_last_operation, operation + '.lastoperation.blue.json')

--- a/lib/config.py
+++ b/lib/config.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 from argparse import ArgumentParser
 from .utils.merge_dict import merge_dict
 from .logger import init_logger
@@ -99,6 +100,24 @@ def _get_parameters_restore_optional():
 def _get_parameters_blob_operation():
     return merge_dict(parameters, parameters_blob_operation)
 
+def remove_all_files(dir_path):
+    if os.path.exists(dir_path):
+        shutil.rmtree(dir_path)
+        os.makedirs(dir_path)
+
+# this function will remove all the files in the directories pointed by SF_BACKUP_RESTORE_LOG_DIRECTORY
+# and SF_BACKUP_RESTORE_LAST_OPERATION_DIRECTORY
+def remove_old_logs_state():
+    directory_logfile = os.getenv('SF_BACKUP_RESTORE_LOG_DIRECTORY')
+    directory_last_operation = os.getenv('SF_BACKUP_RESTORE_LAST_OPERATION_DIRECTORY')
+
+    # Verify that the required environment variables are provided
+    assert directory_logfile is not None, 'SF_BACKUP_RESTORE_LOG_DIRECTORY environment variable is not set.'
+    assert directory_last_operation is not None, 'SF_BACKUP_RESTORE_LAST_OPERATION_DIRECTORY environment variable is not set.'
+
+    remove_all_files(directory_logfile)
+    remove_all_files(directory_last_operation)
+    
 def parse_options(type):
     """Parse the required command line options for the given operation type.
 
@@ -110,6 +129,10 @@ def parse_options(type):
 
             configuration = parse_options('backup')
     """
+
+    # first, remove all the old logs and data
+    remove_old_logs_state()
+
     # TODO: conflict_handler='resolve' is really required ??
     parser = ArgumentParser(conflict_handler='resolve')
     if type == 'backup':

--- a/lib/config.py
+++ b/lib/config.py
@@ -114,27 +114,15 @@ def remove_old_logs_state():
         path_log = os.path.join(directory_logfile, operation + '.log')
         path_blue = os.path.join(directory_last_operation, operation + '.lastoperation.blue.json')
         path_green = os.path.join(directory_last_operation, operation + '.lastoperation.green.json')
+        path_output_json = os.path.join(directory_logfile, operation + '.output.json')
         
         # +-> open a new file if it doesn't exist, and truncate if file exists.
         open(path_log, 'w+').close()
         open(path_blue, 'w+').close()
         open(path_green, 'w+').close()
+        open(path_output_json, 'w+').close()
 
-def parse_options(type):
-    """Parse the required command line options for the given operation type.
-
-    :param type: a string containing either `backup` or `restore`
-    :returns: a dictionary containing the key-value pairs of the provided parameters
-
-    :Example:
-        ::
-
-            configuration = parse_options('backup')
-    """
-
-    # first, remove all the old logs and data
-    remove_old_logs_state()
-
+def build_parser():
     # TODO: conflict_handler='resolve' is really required ??
     parser = ArgumentParser(conflict_handler='resolve')
     if type == 'backup':
@@ -157,6 +145,26 @@ def parse_options(type):
     for key, credentials in _get_parameters_credentials().items():
         for name, description in credentials.items():
             parser.add_argument('--{}'.format(name), help=description)
+
+    return parser
+
+def parse_options(type):
+    """Parse the required command line options for the given operation type.
+
+    :param type: a string containing either `backup` or `restore`
+    :returns: a dictionary containing the key-value pairs of the provided parameters
+
+    :Example:
+        ::
+
+            configuration = parse_options('backup')
+    """
+
+    # first, remove all the old logs and data
+    remove_old_logs_state()
+
+    parser = build_parser()    
+    
     configuration = vars(parser.parse_args())
     assert configuration['type'] == 'online' or configuration['type'] == 'offline', \
         '--type must be \'online\' or \'offline\''

--- a/tests/test_clients_GcpClient.py
+++ b/tests/test_clients_GcpClient.py
@@ -1,5 +1,6 @@
 import os
 import unittest.mock
+from tests.utils.utilities import create_start_patcher, stop_all_patchers
 import pytest
 import json
 import glob
@@ -481,28 +482,6 @@ def get_device_of_volume(volume_id):
     else:
         return None
 
-
-def create_start_patcher(patch_function, patch_object=None, return_value=None, side_effect=None):
-    if patch_object != None:
-        patcher = patch.object(patch_object, patch_function)
-    else:
-        patcher = patch(patch_function)
-
-    patcher_start = patcher.start()
-    if return_value != None:
-        patcher_start.return_value = return_value
-
-    if side_effect != None:
-        patcher_start.side_effect = side_effect
-
-    return patcher
-
-
-def stop_all_patchers(patchers):
-    for patcher in patchers:
-        patcher.stop()
-
-
 class TestGcpClient:
     # Store all patchers
     patchers = []
@@ -510,33 +489,33 @@ class TestGcpClient:
     @classmethod
     def setup_class(self):
         self.patchers.append(create_start_patcher(
-            patch_function='_get_device_of_volume', patch_object=BaseClient, side_effect=get_device_of_volume))
+            patch_function='_get_device_of_volume', patch_object=BaseClient, side_effect=get_device_of_volume)['patcher'])
         self.patchers.append(create_start_patcher(
-            patch_function='delete_snapshot', patch_object=BaseClient, return_value=True))
+            patch_function='delete_snapshot', patch_object=BaseClient, return_value=True)['patcher'])
         self.patchers.append(create_start_patcher(
-            patch_function='delete_volume', patch_object=BaseClient, return_value=True))
+            patch_function='delete_volume', patch_object=BaseClient, return_value=True)['patcher'])
         self.patchers.append(create_start_patcher(
-            patch_function='glob', patch_object=glob, side_effect=mockglob))
+            patch_function='glob', patch_object=glob, side_effect=mockglob)['patcher'])
         self.patchers.append(create_start_patcher(patch_function='generate_name_by_prefix',
-                                                  patch_object=BaseClient, side_effect=generate_name_by_prefix))
+                                                  patch_object=BaseClient, side_effect=generate_name_by_prefix)['patcher'])
         self.patchers.append(create_start_patcher(
-            patch_function='shell', patch_object=BaseClient, side_effect=shell))
+            patch_function='shell', patch_object=BaseClient, side_effect=shell)['patcher'])
         self.patchers.append(create_start_patcher(
-            patch_function='last_operation', patch_object=BaseClient))
+            patch_function='last_operation', patch_object=BaseClient)['patcher'])
         self.patchers.append(create_start_patcher(
-            patch_function='google.oauth2.service_account.Credentials.from_service_account_info'))
+            patch_function='google.oauth2.service_account.Credentials.from_service_account_info')['patcher'])
         self.patchers.append(create_start_patcher(
-            patch_function='googleapiclient.discovery.build', return_value=ComputeClient()))
+            patch_function='googleapiclient.discovery.build', return_value=ComputeClient())['patcher'])
         self.patchers.append(create_start_patcher(
-            patch_function='google.cloud.storage.Client', return_value=StorageClient()))
+            patch_function='google.cloud.storage.Client', return_value=StorageClient())['patcher'])
         self.patchers.append(create_start_patcher(
-            patch_function='google.cloud.storage.Blob.upload_from_string'))
+            patch_function='google.cloud.storage.Blob.upload_from_string')['patcher'])
         self.patchers.append(create_start_patcher(
-            patch_function='google.cloud.storage.Blob.delete'))
+            patch_function='google.cloud.storage.Blob.delete')['patcher'])
         self.patchers.append(create_start_patcher(
-            patch_function='upload_from_filename', patch_object=Blob, side_effect=upload_from_filename))
+            patch_function='upload_from_filename', patch_object=Blob, side_effect=upload_from_filename)['patcher'])
         self.patchers.append(create_start_patcher(
-            patch_function='download_to_filename', patch_object=Blob, side_effect=download_to_filename))
+            patch_function='download_to_filename', patch_object=Blob, side_effect=download_to_filename)['patcher'])
 
         os.environ['SF_BACKUP_RESTORE_LOG_DIRECTORY'] = log_dir
         os.environ['SF_BACKUP_RESTORE_LAST_OPERATION_DIRECTORY'] = log_dir
@@ -812,11 +791,11 @@ class TestGcpClientExceptions:
     @classmethod
     def setup_class(self):
         self.patchers.append(create_start_patcher(
-            patch_function='google.oauth2.service_account.Credentials.from_service_account_info'))
+            patch_function='google.oauth2.service_account.Credentials.from_service_account_info')['patcher'])
         self.patchers.append(create_start_patcher(
-            patch_function='googleapiclient.discovery.build', return_value=ComputeClient()))
+            patch_function='googleapiclient.discovery.build', return_value=ComputeClient())['patcher'])
         self.patchers.append(create_start_patcher(
-            patch_function='google.cloud.storage.Client', return_value=StorageClient()))
+            patch_function='google.cloud.storage.Client', return_value=StorageClient())['patcher'])
 
     @classmethod
     def teardown_class(self):
@@ -829,9 +808,9 @@ class TestGcpClientExceptions:
 
     def test_gcp_client_raises_availability_zone_exception(self):
         mock_blob_upload_patcher = create_start_patcher(
-            patch_function='google.cloud.storage.Blob.upload_from_string')
+            patch_function='google.cloud.storage.Blob.upload_from_string')['patcher']
         mock_blob_delete_patcher = create_start_patcher(
-            patch_function='google.cloud.storage.Blob.delete')
+            patch_function='google.cloud.storage.Blob.delete')['patcher']
         configuration['instance_id'] = invalid_vm_id
         with pytest.raises(Exception, message='Could not retrieve the availability zone of the instance.'):
             GcpClient(operation_name, configuration, directory_persistent, directory_work_list,

--- a/tests/test_clients_OpenstackClient.py
+++ b/tests/test_clients_OpenstackClient.py
@@ -1,6 +1,7 @@
 import os
 import pytest
 import ast
+from tests.utils.utilities import create_start_patcher, stop_all_patchers
 from lib.clients.OpenstackClient import OpenstackClient
 from lib.clients.BaseClient import BaseClient
 from unittest.mock import patch
@@ -146,28 +147,6 @@ def file_to_dict(file_path):
     f.close()
     return ast.literal_eval(text)
 
-
-def create_start_patcher(patch_function, patch_object=None, return_value=None, side_effect=None):
-    if patch_object != None:
-        patcher = patch.object(patch_object, patch_function)
-    else:
-        patcher = patch(patch_function)
-
-    patcher_start = patcher.start()
-    if return_value != None:
-        patcher_start.return_value = return_value
-
-    if side_effect != None:
-        patcher_start.side_effect = side_effect
-
-    return patcher
-
-
-def stop_all_patchers(patchers):
-    for patcher in patchers:
-        patcher.stop()
-
-
 class TestOpenstackClient:
     # Store all patchers
     patchers = []
@@ -175,21 +154,21 @@ class TestOpenstackClient:
     @classmethod
     def setup_class(self):
         self.patchers.append(create_start_patcher(
-            patch_function='last_operation', patch_object=BaseClient))
+            patch_function='last_operation', patch_object=BaseClient)['patcher'])
         self.patchers.append(create_start_patcher(
-            patch_function='keystoneauth1.identity.v3.Password'))
+            patch_function='keystoneauth1.identity.v3.Password')['patcher'])
         self.patchers.append(create_start_patcher(
-            patch_function='keystoneauth1.session.Session'))
+            patch_function='keystoneauth1.session.Session')['patcher'])
         self.patchers.append(create_start_patcher(
-            patch_function='get_project_id', patch_object=KeystoneSession))
+            patch_function='get_project_id', patch_object=KeystoneSession)['patcher'])
         self.patchers.append(create_start_patcher(
-            patch_function='create_cinder_client', patch_object=OpenstackClient, return_value=CinderClient()))
+            patch_function='create_cinder_client', patch_object=OpenstackClient, return_value=CinderClient())['patcher'])
         self.patchers.append(create_start_patcher(
-            patch_function='create_nova_client', patch_object=OpenstackClient, return_value=NovaClient()))
+            patch_function='create_nova_client', patch_object=OpenstackClient, return_value=NovaClient())['patcher'])
         self.patchers.append(create_start_patcher(
-            patch_function='create_swift_client', patch_object=OpenstackClient, return_value=SwiftClient()))
+            patch_function='create_swift_client', patch_object=OpenstackClient, return_value=SwiftClient())['patcher'])
         self.patchers.append(create_start_patcher(
-            patch_function='create_swift_service', patch_object=OpenstackClient, return_value=SwiftService()))
+            patch_function='create_swift_service', patch_object=OpenstackClient, return_value=SwiftService())['patcher'])
 
         os.environ['SF_BACKUP_RESTORE_LOG_DIRECTORY'] = log_dir
         os.environ['SF_BACKUP_RESTORE_LAST_OPERATION_DIRECTORY'] = log_dir

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -159,7 +159,7 @@ class TestConfig():
         
         directory_logfile = os.getenv('SF_BACKUP_RESTORE_LOG_DIRECTORY')
         directory_last_operation = os.getenv('SF_BACKUP_RESTORE_LAST_OPERATION_DIRECTORY')
-        for operation in ['backup', 'restore', 'blob_operation']:   
+        for operation in ['backup', 'restore']:   
             # +-> Define paths for log and last operation file
             path_log = os.path.join(directory_logfile, operation + '.log')
             path_blue = os.path.join(directory_last_operation, operation + '.lastoperation.blue.json')

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,172 @@
+from tests.utils.utilities import create_start_patcher, stop_all_patchers
+import tests.utils.setup_constants
+import os
+import pytest
+import unittest.mock as mock
+import unittest
+from lib.config import build_parser, remove_old_logs_state
+import sys
+
+# test data
+
+default_parameters = {
+    'iaas': 'aws',
+    'type': 'online'
+}
+
+credentials_parameters = {
+    'aws': {
+        'access_key_id': 'secret-key',
+        'secret_access_key': 'secret-access-key',
+        'region_name': 'valid-region-name',
+        'max_retries': 'valid-max-retries'
+    },
+}
+
+ops_parameters = {
+    'backup' : {
+        'backup_guid': 'valid-backup-guid',
+        'instance_id': 'valid-instance-id',
+        'secret': 'valid-secret',
+        'container': 'valid-container-name',
+        'job_name': 'valid-job-name'
+    },
+    'restore': {
+        'backup_guid': 'valid-backup-guid',
+        'instance_id': 'valid-instance-id',
+        'secret': 'valid-secret',
+        'container': 'valid-container-name',
+        'job_name': 'valid-job-name',
+        'agent_id': 'valid-agent-id',
+        'agent_ip': 'valid-agent-ip'
+    },
+
+    'blob_operation': {
+        'container': 'valid-container-name'
+    }
+}
+
+restore_optional_parameters = {
+    'agent_id': 'valid-agent-id',
+    'agent_ip': 'valid-agent-ip'
+}
+
+def create_operation_parameters(operation_name):
+    operation_parameters = []
+
+    # default parameters
+    for key, value in default_parameters.items():
+        operation_parameters.append('--{}'.format(key))
+        operation_parameters.append(value)
+
+    # operation specific parameters
+    op_specific_parameters = ops_parameters[operation_name] #operation_name = 'backup'/'restore'
+    for key, value in op_specific_parameters.items():
+        operation_parameters.append('--{}'.format(key))
+        operation_parameters.append(value)
+
+    # credentials parameters
+    for iaas, credentials in credentials_parameters.items():
+        for key, value in credentials.items():
+            operation_parameters.append('--{}'.format(key))
+            operation_parameters.append(value)
+
+    return operation_parameters
+
+# tests
+class TestConfig():
+    patchers = []
+    @classmethod
+    def setup_class(self):
+        pass
+
+    @classmethod
+    def teardown_class(self):
+        pass
+
+    def test_build_parser_backup(self):
+        #build the parser for backup
+        parser = build_parser('backup')
+
+        #build parameters for backup
+        params = create_operation_parameters('backup')
+
+        #pass these parameters to parser and test configuration
+        configuration = vars(parser.parse_args(params))
+        
+        assert configuration['iaas'] == default_parameters['iaas']
+        assert configuration['type'] == default_parameters['type']
+        
+        assert configuration['access_key_id'] == credentials_parameters['aws']['access_key_id']
+        assert configuration['secret_access_key'] == credentials_parameters['aws']['secret_access_key']
+        assert configuration['region_name'] == credentials_parameters['aws']['region_name']
+        assert configuration['max_retries'] == credentials_parameters['aws']['max_retries'] 
+        assert configuration['backup_guid'] == ops_parameters['backup']['backup_guid']
+        assert configuration['instance_id'] == ops_parameters['backup']['instance_id']
+        assert configuration['secret'] == ops_parameters['backup']['secret']
+        assert configuration['container'] == ops_parameters['backup']['container']
+        assert configuration['job_name'] == ops_parameters['backup']['job_name']
+
+    def test_build_parser_restore(self):
+        #build the parser for restore
+        parser = build_parser('restore')
+
+        #build parameters for restore
+        params = create_operation_parameters('restore')
+
+        #pass these parameters to parser and test configuration
+        configuration = vars(parser.parse_args(params))
+        
+        assert configuration['iaas'] == default_parameters['iaas']
+        assert configuration['type'] == default_parameters['type']
+        
+        assert configuration['access_key_id'] == credentials_parameters['aws']['access_key_id']
+        assert configuration['secret_access_key'] == credentials_parameters['aws']['secret_access_key']
+        assert configuration['region_name'] == credentials_parameters['aws']['region_name']
+        assert configuration['max_retries'] == credentials_parameters['aws']['max_retries']
+        assert configuration['backup_guid'] == ops_parameters['restore']['backup_guid']
+        assert configuration['instance_id'] == ops_parameters['restore']['instance_id']
+        assert configuration['secret'] == ops_parameters['restore']['secret']
+        assert configuration['container'] == ops_parameters['restore']['container']
+        assert configuration['job_name'] == ops_parameters['restore']['job_name']
+        assert configuration['agent_id'] == ops_parameters['restore']['agent_id']
+        assert configuration['agent_ip'] == ops_parameters['restore']['agent_ip']
+
+    def test_build_parser_blob_operation(self):
+        #build the parser for restore
+        parser = build_parser('blob_operation')
+
+        #build parameters for restore
+        params = create_operation_parameters('blob_operation')
+
+        #pass these parameters to parser and test configuration
+        configuration = vars(parser.parse_args(params))
+        
+        assert configuration['iaas'] == default_parameters['iaas']
+        assert configuration['type'] == default_parameters['type']
+
+        assert configuration['container'] == ops_parameters['blob_operation']['container']
+
+    def test_build_parser_exception(self):
+        with pytest.raises(Exception) as e:
+            build_parser('invalid_type')
+            assert e.message == 'Use either \'backup\' or \'restore\' as type.'
+
+    def test_remove_old_logs(self):
+        m = mock.mock_open()
+        with mock.patch('builtins.open', m):
+            remove_old_logs_state()
+        
+        directory_logfile = os.getenv('SF_BACKUP_RESTORE_LOG_DIRECTORY')
+        directory_last_operation = os.getenv('SF_BACKUP_RESTORE_LAST_OPERATION_DIRECTORY')
+        for operation in ['backup', 'restore', 'blob_operation']:   
+            # +-> Define paths for log and last operation file
+            path_log = os.path.join(directory_logfile, operation + '.log')
+            path_blue = os.path.join(directory_last_operation, operation + '.lastoperation.blue.json')
+            path_green = os.path.join(directory_last_operation, operation + '.lastoperation.green.json')
+            path_output_json = os.path.join(directory_logfile, operation + '.output.json')
+
+            m.assert_any_call(path_log, 'w+')
+            m.assert_any_call(path_blue, 'w+')
+            m.assert_any_call(path_green, 'w+')
+            m.assert_any_call(path_output_json, 'w+')

--- a/tests/utils/setup_constants.py
+++ b/tests/utils/setup_constants.py
@@ -2,3 +2,5 @@ import os
 
 #setting environment varibale before importing module 
 os.environ['SF_IAAS_CLIENT_MAX_RETRY'] = '1'
+os.environ['SF_BACKUP_RESTORE_LOG_DIRECTORY'] = 'tests/logs'
+os.environ['SF_BACKUP_RESTORE_LAST_OPERATION_DIRECTORY'] = 'tests/logs'


### PR DESCRIPTION
* Currently logs and other state of the previous backup/restore operation is cleared as part of create_iaas_client operation. However if operation fails before/within create_iaas_client, previous state and logs will still be present and hence external agent will conclude wrong result.
* This PR solves this problem by including this removal of logs in the very first call to library, i.e., inside parse_options operation.
* Apart from this, config.py is refactored for the ease of unit testing and readability. UTs for config.py are also added
* Duplicate of #51 .