### PR TITLE
Fix VMware volume detection

### DIFF
--- a/lib/clients/OpenstackClient.py
+++ b/lib/clients/OpenstackClient.py
@@ -336,7 +336,7 @@ class OpenstackClient(BaseClient):
         self.shell('udevadm trigger', False)
         # create symbol links at /dev/disk/by-id/virtio-<uuid> pointing to the real device name
         time.sleep(3)
-        result = self.shell('ls /dev/disk/by-id/ | grep {}'.format(volume_id[:20]), False)
+        result = self.shell('ls /dev/disk/by-id/ | egrep {}'.format(volume_id[:20].replace('-', '-?')), False)
         if result:
             result = '/dev/disk/by-id/{}'.format(result.split('\n')[0])
         return result


### PR DESCRIPTION
When OpenStack VMs are running inside the VMware hypervisors, the uuid detection doesn't work, because symlinks for VMware devices are made without hyphens, e.g.:

```sh
$ ls /dev/disk/by-id/ | grep 6b81837496cd4b8f8bc470dd4c34d5a2
wwn-0x6b81837496cd4b8f8bc470dd4c34d5a2
```

corresponds to the `6b818374-96cd-4b8f-8bc4-70dd4c34d5a2` cinder volume ID.

The suggested fix resolves disk detection.