### PR TITLE
Added 404 handling in delete opeartions for alicloud, aws, gcp and azure

### DIFF
--- a/lib/clients/AliClient.py
+++ b/lib/clients/AliClient.py
@@ -547,8 +547,6 @@ class AliClient(BaseClient):
                 self.logger.info(message)
                 self.logger.info('ignoring this error for delete operation..')
                 return True
-            message = '{} ERROR: volume-id={}, instance-id={}\n{}'.format(
-                log_prefix, volume_id, instance_id, error)
             self.logger.error(message)
             raise Exception(message)
 

--- a/lib/clients/AliClient.py
+++ b/lib/clients/AliClient.py
@@ -280,6 +280,9 @@ class AliClient(BaseClient):
         except Exception as error:
             message = '{} ERROR: snapshot-id={}\n{}'.format(
                 log_prefix, snapshot_id, error)
+            if error.get_http_status() == 404:
+                self.logger.info(message)
+                return True
             self.logger.error(message)
             raise Exception(message)
 
@@ -439,6 +442,9 @@ class AliClient(BaseClient):
         except Exception as error:
             message = '{} ERROR: volume-id={}\n{}'.format(
                 log_prefix, volume_id, error)
+            if error.get_http_status() == 404:
+                self.logger.info(message)
+                return True
             self.logger.error(message)
             raise Exception(message)
 
@@ -533,6 +539,11 @@ class AliClient(BaseClient):
                 '{} SUCCESS: volume-id={}, instance-id={}'.format(log_prefix, volume_id, instance_id))
             return True
         except Exception as error:
+            message = '{} ERROR: volume-id={}, instance-id={}\n{}'.format(
+                log_prefix, volume_id, instance_id, error)
+            if error.get_http_status() == 404:
+                self.logger.info(message)
+                return True
             message = '{} ERROR: volume-id={}, instance-id={}\n{}'.format(
                 log_prefix, volume_id, instance_id, error)
             self.logger.error(message)

--- a/lib/clients/AliClient.py
+++ b/lib/clients/AliClient.py
@@ -282,6 +282,7 @@ class AliClient(BaseClient):
                 log_prefix, snapshot_id, error)
             if error.get_http_status() == 404:
                 self.logger.info(message)
+                self.logger.info('ignoring this error for delete operation..')
                 return True
             self.logger.error(message)
             raise Exception(message)
@@ -444,6 +445,7 @@ class AliClient(BaseClient):
                 log_prefix, volume_id, error)
             if error.get_http_status() == 404:
                 self.logger.info(message)
+                self.logger.info('ignoring this error for delete operation..')
                 return True
             self.logger.error(message)
             raise Exception(message)
@@ -543,6 +545,7 @@ class AliClient(BaseClient):
                 log_prefix, volume_id, instance_id, error)
             if error.get_http_status() == 404:
                 self.logger.info(message)
+                self.logger.info('ignoring this error for delete operation..')
                 return True
             message = '{} ERROR: volume-id={}, instance-id={}\n{}'.format(
                 log_prefix, volume_id, instance_id, error)

--- a/lib/clients/AwsClient.py
+++ b/lib/clients/AwsClient.py
@@ -247,12 +247,11 @@ class AwsClient(BaseClient):
                 '{} SUCCESS: snapshot-id={}'.format(log_prefix, snapshot_id))
             return True
         except Exception as error:
-            if error.response['ResponseMetadata']['HTTPStatusCode'] == 404:
-                message = '{} NOT FOUND: volume-id={}\n{}\nIgnoring NOT FOUND error, moving to next step...'.format(log_prefix, volume_id, error)
-                self.logger.info(message)
-                return True
             message = '{} ERROR: snapshot-id={}\n{}'.format(
                 log_prefix, snapshot_id, error)
+            if error.response['ResponseMetadata']['HTTPStatusCode'] == 404:
+                self.logger.info(message)
+                return True
             self.logger.error(message)
             raise Exception(message)
 
@@ -316,12 +315,11 @@ class AwsClient(BaseClient):
                 '{} SUCCESS: volume-id={}'.format(log_prefix, volume_id))
             return True
         except Exception as error:
-            if error.response['ResponseMetadata']['HTTPStatusCode'] == 404:
-                message = '{} NOT FOUND: volume-id={}\n{}\nIgnoring NOT FOUND error, moving to next step...'.format(log_prefix, volume_id, error)
-                self.logger.info(message)
-                return True
             message = '{} ERROR: volume-id={}\n{}'.format(
                 log_prefix, volume_id, error)
+            if error.response['ResponseMetadata']['HTTPStatusCode'] == 404:
+                self.logger.info(message)
+                return True
             self.logger.error(message)
             raise Exception(message)
 
@@ -396,12 +394,11 @@ class AwsClient(BaseClient):
                 '{} SUCCESS: volume-id={}, instance-id={}'.format(log_prefix, volume_id, instance_id))
             return True
         except Exception as error:
-            if error.response['ResponseMetadata']['HTTPStatusCode'] == 404:
-                message = '{} NOT FOUND: volume-id={}\n{}\nIgnoring NOT FOUND error, moving to next step...'.format(log_prefix, volume_id, error)
-                self.logger.info(message)
-                return True
             message = '{} ERROR: volume-id={}, instance-id={}\n{}'.format(
                 log_prefix, volume_id, instance_id, error)
+            if error.response['ResponseMetadata']['HTTPStatusCode'] == 404:
+                self.logger.info(message)
+                return True
             self.logger.error(message)
             raise Exception(message)
 

--- a/lib/clients/AwsClient.py
+++ b/lib/clients/AwsClient.py
@@ -251,6 +251,7 @@ class AwsClient(BaseClient):
                 log_prefix, snapshot_id, error)
             if error.response['ResponseMetadata']['HTTPStatusCode'] == 404:
                 self.logger.info(message)
+                self.logger.info('ignoring this error for delete operation..')
                 return True
             self.logger.error(message)
             raise Exception(message)
@@ -319,6 +320,7 @@ class AwsClient(BaseClient):
                 log_prefix, volume_id, error)
             if error.response['ResponseMetadata']['HTTPStatusCode'] == 404:
                 self.logger.info(message)
+                self.logger.info('ignoring this error for delete operation..')
                 return True
             self.logger.error(message)
             raise Exception(message)
@@ -398,6 +400,7 @@ class AwsClient(BaseClient):
                 log_prefix, volume_id, instance_id, error)
             if error.response['ResponseMetadata']['HTTPStatusCode'] == 404:
                 self.logger.info(message)
+                self.logger.info('ignoring this error for delete operation..')
                 return True
             self.logger.error(message)
             raise Exception(message)

--- a/lib/clients/AwsClient.py
+++ b/lib/clients/AwsClient.py
@@ -247,6 +247,10 @@ class AwsClient(BaseClient):
                 '{} SUCCESS: snapshot-id={}'.format(log_prefix, snapshot_id))
             return True
         except Exception as error:
+            if error.response['ResponseMetadata']['HTTPStatusCode'] == 404:
+                message = '{} NOT FOUND: volume-id={}\n{}\nIgnoring NOT FOUND error, moving to next step...'.format(log_prefix, volume_id, error)
+                self.logger.info(message)
+                return True
             message = '{} ERROR: snapshot-id={}\n{}'.format(
                 log_prefix, snapshot_id, error)
             self.logger.error(message)
@@ -312,6 +316,10 @@ class AwsClient(BaseClient):
                 '{} SUCCESS: volume-id={}'.format(log_prefix, volume_id))
             return True
         except Exception as error:
+            if error.response['ResponseMetadata']['HTTPStatusCode'] == 404:
+                message = '{} NOT FOUND: volume-id={}\n{}\nIgnoring NOT FOUND error, moving to next step...'.format(log_prefix, volume_id, error)
+                self.logger.info(message)
+                return True
             message = '{} ERROR: volume-id={}\n{}'.format(
                 log_prefix, volume_id, error)
             self.logger.error(message)
@@ -388,6 +396,10 @@ class AwsClient(BaseClient):
                 '{} SUCCESS: volume-id={}, instance-id={}'.format(log_prefix, volume_id, instance_id))
             return True
         except Exception as error:
+            if error.response['ResponseMetadata']['HTTPStatusCode'] == 404:
+                message = '{} NOT FOUND: volume-id={}\n{}\nIgnoring NOT FOUND error, moving to next step...'.format(log_prefix, volume_id, error)
+                self.logger.info(message)
+                return True
             message = '{} ERROR: volume-id={}, instance-id={}\n{}'.format(
                 log_prefix, volume_id, instance_id, error)
             self.logger.error(message)

--- a/lib/clients/AzureClient.py
+++ b/lib/clients/AzureClient.py
@@ -303,12 +303,11 @@ class AzureClient(BaseClient):
                     log_prefix, snapshot_id, snapshot_delete_response))
             return True
         except Exception as error:
+            message = '{} ERROR: snapshot_id={}\n{}'.format(
+                log_prefix, snapshot_id, error)
             if error.status_code == 404:
-                message = '{} NOT FOUND: volume-id={}\n{}\nIgnoring NOT FOUND error, moving to next step...'.format(log_prefix, volume_id, error)
                 self.logger.info(message)
                 return True
-            message = '{} ERROR: snapshot-id={}\n{}'.format(
-                log_prefix, snapshot_id, error)
             self.logger.error(message)
             raise Exception(message)
 
@@ -391,12 +390,11 @@ class AzureClient(BaseClient):
                     log_prefix, volume_id, self.tags, delete_response))
             return True
         except Exception as error:
-            if error.status_code == 404:
-                message = '{} NOT FOUND: volume-id={}\n{}\nIgnoring NOT FOUND error, moving to next step...'.format(log_prefix, volume_id, error)
-                self.logger.info(message)
-                return True
             message = '{} ERROR: volume-id={}\n{}'.format(
                 log_prefix, volume_id, error)
+            if error.status_code == 404:
+                self.logger.info(message)
+                return True
             self.logger.error(message)
             raise Exception(message)
 
@@ -511,12 +509,11 @@ class AzureClient(BaseClient):
                     log_prefix, volume_id, instance_id, updated_vm))
             return True
         except Exception as error:
-            if error.status_code == 404:
-                message = '{} NOT FOUND: volume-id={}\n{}\nIgnoring NOT FOUND error, moving to next step...'.format(log_prefix, volume_id, error)
-                self.logger.info(message)
-                return True
             message = '{} ERROR: volume-id={}, instance-id={}\n{}'.format(
                 log_prefix, volume_id, instance_id, error)
+            if error.status_code == 404:
+                self.logger.info(message)
+                return True
             self.logger.error(message)
             raise Exception(message)
 

--- a/lib/clients/AzureClient.py
+++ b/lib/clients/AzureClient.py
@@ -307,6 +307,7 @@ class AzureClient(BaseClient):
                 log_prefix, snapshot_id, error)
             if error.status_code == 404:
                 self.logger.info(message)
+                self.logger.info('ignoring this error for delete operation..')
                 return True
             self.logger.error(message)
             raise Exception(message)
@@ -394,6 +395,7 @@ class AzureClient(BaseClient):
                 log_prefix, volume_id, error)
             if error.status_code == 404:
                 self.logger.info(message)
+                self.logger.info('ignoring this error for delete operation..')
                 return True
             self.logger.error(message)
             raise Exception(message)
@@ -513,6 +515,7 @@ class AzureClient(BaseClient):
                 log_prefix, volume_id, instance_id, error)
             if error.status_code == 404:
                 self.logger.info(message)
+                self.logger.info('ignoring this error for delete operation..')
                 return True
             self.logger.error(message)
             raise Exception(message)

--- a/lib/clients/AzureClient.py
+++ b/lib/clients/AzureClient.py
@@ -303,6 +303,10 @@ class AzureClient(BaseClient):
                     log_prefix, snapshot_id, snapshot_delete_response))
             return True
         except Exception as error:
+            if error.status_code == 404:
+                message = '{} NOT FOUND: volume-id={}\n{}\nIgnoring NOT FOUND error, moving to next step...'.format(log_prefix, volume_id, error)
+                self.logger.info(message)
+                return True
             message = '{} ERROR: snapshot-id={}\n{}'.format(
                 log_prefix, snapshot_id, error)
             self.logger.error(message)
@@ -387,6 +391,10 @@ class AzureClient(BaseClient):
                     log_prefix, volume_id, self.tags, delete_response))
             return True
         except Exception as error:
+            if error.status_code == 404:
+                message = '{} NOT FOUND: volume-id={}\n{}\nIgnoring NOT FOUND error, moving to next step...'.format(log_prefix, volume_id, error)
+                self.logger.info(message)
+                return True
             message = '{} ERROR: volume-id={}\n{}'.format(
                 log_prefix, volume_id, error)
             self.logger.error(message)
@@ -503,6 +511,10 @@ class AzureClient(BaseClient):
                     log_prefix, volume_id, instance_id, updated_vm))
             return True
         except Exception as error:
+            if error.status_code == 404:
+                message = '{} NOT FOUND: volume-id={}\n{}\nIgnoring NOT FOUND error, moving to next step...'.format(log_prefix, volume_id, error)
+                self.logger.info(message)
+                return True
             message = '{} ERROR: volume-id={}, instance-id={}\n{}'.format(
                 log_prefix, volume_id, instance_id, error)
             self.logger.error(message)

--- a/lib/clients/GcpClient.py
+++ b/lib/clients/GcpClient.py
@@ -289,6 +289,10 @@ class GcpClient(BaseClient):
                 self.logger.error(message)
                 raise Exception(message)
         except Exception as error:
+            if self.get_http_error_code(error) == 404:
+                message = '{} NOT FOUND: volume-id={}\n{}\nIgnoring NOT FOUND error, moving to next step...'.format(log_prefix, volume_id, error)
+                self.logger.info(message)
+                return True
             message = '{} ERROR: snapshot-id={}\n{}'.format(
                 log_prefix, snapshot_id, error)
             self.logger.error(message)
@@ -369,6 +373,10 @@ class GcpClient(BaseClient):
                 self.logger.error(message)
                 raise Exception(message)
         except Exception as error:
+            if self.get_http_error_code(error) == 404:
+                message = '{} NOT FOUND: volume-id={}\n{}\nIgnoring NOT FOUND error, moving to next step...'.format(log_prefix, volume_id, error)
+                self.logger.info(message)
+                return True
             message = '{} ERROR: volume-id={}\n{}'.format(
                 log_prefix, volume_id, error)
             self.logger.error(message)
@@ -453,6 +461,10 @@ class GcpClient(BaseClient):
                 '{} SUCCESS: volume-id={}, instance-id={}'.format(log_prefix, volume_id, instance_id))
             return True
         except Exception as error:
+            if self.get_http_error_code(error) == 404:
+                message = '{} NOT FOUND: volume-id={}\n{}\nIgnoring NOT FOUND error, moving to next step...'.format(log_prefix, volume_id, error)
+                self.logger.info(message)
+                return True
             message = '{} ERROR: volume-id={}, instance-id={}\n{}'.format(
                 log_prefix, volume_id, instance_id, error)
             self.logger.error(message)

--- a/lib/clients/GcpClient.py
+++ b/lib/clients/GcpClient.py
@@ -293,6 +293,7 @@ class GcpClient(BaseClient):
                 log_prefix, snapshot_id, error)
             if self.get_http_error_code(error) == 404:
                 self.logger.info(message)
+                self.logger.info('ignoring this error for delete operation..')
                 return True
             self.logger.error(message)
             raise Exception(message)
@@ -376,6 +377,7 @@ class GcpClient(BaseClient):
                 log_prefix, volume_id, error)
             if self.get_http_error_code(error) == 404:
                 self.logger.info(message)
+                self.logger.info('ignoring this error for delete operation..')
                 return True
             self.logger.error(message)
             raise Exception(message)
@@ -463,6 +465,7 @@ class GcpClient(BaseClient):
                 log_prefix, volume_id, instance_id, error)
             if self.get_http_error_code(error) == 404:
                 self.logger.info(message)
+                self.logger.info('ignoring this error for delete operation..')
                 return True
             self.logger.error(message)
             raise Exception(message)

--- a/lib/clients/GcpClient.py
+++ b/lib/clients/GcpClient.py
@@ -289,12 +289,11 @@ class GcpClient(BaseClient):
                 self.logger.error(message)
                 raise Exception(message)
         except Exception as error:
-            if self.get_http_error_code(error) == 404:
-                message = '{} NOT FOUND: volume-id={}\n{}\nIgnoring NOT FOUND error, moving to next step...'.format(log_prefix, volume_id, error)
-                self.logger.info(message)
-                return True
             message = '{} ERROR: snapshot-id={}\n{}'.format(
                 log_prefix, snapshot_id, error)
+            if self.get_http_error_code(error) == 404:
+                self.logger.info(message)
+                return True
             self.logger.error(message)
             raise Exception(message)
 
@@ -373,12 +372,11 @@ class GcpClient(BaseClient):
                 self.logger.error(message)
                 raise Exception(message)
         except Exception as error:
-            if self.get_http_error_code(error) == 404:
-                message = '{} NOT FOUND: volume-id={}\n{}\nIgnoring NOT FOUND error, moving to next step...'.format(log_prefix, volume_id, error)
-                self.logger.info(message)
-                return True
             message = '{} ERROR: volume-id={}\n{}'.format(
                 log_prefix, volume_id, error)
+            if self.get_http_error_code(error) == 404:
+                self.logger.info(message)
+                return True
             self.logger.error(message)
             raise Exception(message)
 
@@ -461,12 +459,11 @@ class GcpClient(BaseClient):
                 '{} SUCCESS: volume-id={}, instance-id={}'.format(log_prefix, volume_id, instance_id))
             return True
         except Exception as error:
-            if self.get_http_error_code(error) == 404:
-                message = '{} NOT FOUND: volume-id={}\n{}\nIgnoring NOT FOUND error, moving to next step...'.format(log_prefix, volume_id, error)
-                self.logger.info(message)
-                return True
             message = '{} ERROR: volume-id={}, instance-id={}\n{}'.format(
                 log_prefix, volume_id, instance_id, error)
+            if self.get_http_error_code(error) == 404:
+                self.logger.info(message)
+                return True
             self.logger.error(message)
             raise Exception(message)
 

--- a/tests/test_clients_AliClient.py
+++ b/tests/test_clients_AliClient.py
@@ -66,9 +66,11 @@ disk_detach_id = 'detachdisk1'
 disk_duplicate_id = 'duplicatedisk1'
 disk_create_duplicate_id = 'disk_create_duplicate_id'
 disk_exc_id = 'disk_exc_id'
+disk_404_id = 'disk_404_id'
 disk_attach_error_id = 'disk_attach_error_id'
 
 invalid_vm_id = 'invalid-vm-id'
+notfound_vm_id = 'notfound-vm-id'
 
 directory_persistent = '/var/vcap/store'
 directory_work_list = '/tmp'
@@ -245,8 +247,10 @@ class ComputeClient:
                 response = '{"DiskId": "'+disk_create_duplicate_id+'"}'
             return response.encode('utf-8')
         elif action == 'DeleteDisk':
-            assert params['DiskId'] in (disk_delete_id, disk_create_duplicate_id, disk_exc_id)
+            assert params['DiskId'] in (disk_delete_id, disk_create_duplicate_id, disk_exc_id, disk_404_id)
             if params['DiskId'] == disk_exc_id:
+                raise ServerException('SDK.InvalidRequest','Failed to delete disk', 500)
+            elif params['DiskId'] == disk_404_id:
                 raise ServerException('SDK.InvalidRequest','Failed to delete disk', 404)
             return
         elif action == 'AttachDisk':
@@ -256,9 +260,11 @@ class ComputeClient:
                 raise Exception('Failed to create attachment')
             return
         elif action == 'DetachDisk':
-            assert params['InstanceId'] in (valid_vm_id, invalid_vm_id)
+            assert params['InstanceId'] in (valid_vm_id, invalid_vm_id, notfound_vm_id)
             assert params['DiskId'] in (disk_detach_id,disk_attach_error_id)
             if params['InstanceId'] == invalid_vm_id:
+                raise ServerException('SDK.InvalidRequest','Failed to delete attachment', 500)
+            elif params['InstanceId'] == notfound_vm_id:
                 raise ServerException('SDK.InvalidRequest','Failed to delete attachment', 404)
             return
 
@@ -556,6 +562,13 @@ class TestAliClient:
         except Exception as error:
             assert "Failed to delete disk" in str(error)
 
+    def test_ali_delete_volume_throws_404_exception_on_error(self):
+        try:
+            deleted = self.aliClient._delete_volume(disk_404_id)
+            assert deleted
+        except Exception as error:
+            assert False #error should not be raised
+
     def test_ali_find_volume_device_returns_none_on_error(self):
         assert self.aliClient._find_volume_device(disk_exc_id) is None
 
@@ -592,7 +605,14 @@ class TestAliClient:
         try:
             self.aliClient._delete_attachment(disk_detach_id, invalid_vm_id)
         except Exception as error:
-            assert "Failed to detach" in str(error)
+            assert "Failed to delete attachment" in str(error)
+
+    def test_ali_delete_attachment_throws_404_exception_on_error(self):
+        try:
+            deleted = self.aliClient._delete_attachment(disk_detach_id, notfound_vm_id)
+            assert deleted
+        except Exception as error:
+            assert False
 
     def test_ali_gets_mounpoint_successfully(self):
         assert self.aliClient.get_mountpoint(persistent_disk_id) == persistent_disk_mount_device_id

--- a/tests/test_clients_AliClient.py
+++ b/tests/test_clients_AliClient.py
@@ -1,6 +1,7 @@
 from tests.utils.utilities import create_start_patcher, stop_all_patchers
 
 from lib.clients.AliClient import AliClient
+from aliyunsdkcore.acs_exception.exceptions import ServerException
 from lib.clients.BaseClient import BaseClient
 from lib.models.Snapshot import Snapshot
 from lib.models.Volume import Volume
@@ -194,7 +195,7 @@ class ComputeClient:
         elif action == 'DeleteSnapshot':
             assert params['SnapshotId'] in (snapshot_id, snapshot_delete_id, snapshot_failed_id, snapshot_duplicate_id, snapshot_exc_id)
             if params['SnapshotId'] == snapshot_exc_id:
-                raise Exception('Failed to delete snapshot')
+                raise ServerException('SDK.InvalidRequest','Failed to delete snapshot', 404)
             return
         elif action == 'DescribeDisks':
             assert params['PageSize'] == 10
@@ -243,7 +244,7 @@ class ComputeClient:
         elif action == 'DeleteDisk':
             assert params['DiskId'] in (disk_delete_id, disk_create_duplicate_id, disk_exc_id)
             if params['DiskId'] == disk_exc_id:
-                raise Exception('Failed to delete disk')
+                raise ServerException('SDK.InvalidRequest','Failed to delete disk', 404)
             return
         elif action == 'AttachDisk':
             assert params['InstanceId'] in (valid_vm_id, invalid_vm_id)
@@ -255,7 +256,7 @@ class ComputeClient:
             assert params['InstanceId'] in (valid_vm_id, invalid_vm_id)
             assert params['DiskId'] in (disk_detach_id,disk_attach_error_id)
             if params['InstanceId'] == invalid_vm_id:
-                raise Exception('Failed to detach')
+                raise ServerException('SDK.InvalidRequest','Failed to delete attachment', 404)
             return
 
         return response

--- a/tests/test_clients_GcpClient.py
+++ b/tests/test_clients_GcpClient.py
@@ -213,6 +213,19 @@ class ComputeClient:
                     method=method,
                     headers={}
                 )
+            elif snapshot == not_found_snapshot_name:
+                http = HttpMock(
+                    'tests/data/gcp/snapshots.get.notfound.json', {'status': '404'})
+                model = JsonModel()
+                uri = 'some_uri'
+                method = 'GET'
+                return HttpRequest(
+                    http,
+                    model.response,
+                    uri,
+                    method=method,
+                    headers={}
+                )
 
     class disks:
         def get(self, project, zone, disk):
@@ -302,6 +315,19 @@ class ComputeClient:
                 model = JsonModel()
                 uri = 'some_uri'
                 method = 'DELETE'
+                return HttpRequest(
+                    http,
+                    model.response,
+                    uri,
+                    method=method,
+                    headers={}
+                )
+            elif disk == not_found_disk_name:
+                http = HttpMock(
+                    'tests/data/gcp/disks.get.notfound.json', {'status': '404'})
+                model = JsonModel()
+                uri = 'some_uri'
+                method = 'GET'
                 return HttpRequest(
                     http,
                     model.response,
@@ -633,6 +659,9 @@ class TestGcpClient:
         pytest.raises(Exception, self.gcpClient._delete_snapshot,
                       valid_snapshot_name)
 
+    def test_delete_snapshot_404_exception(self):
+        assert self.gcpClient._delete_snapshot(not_found_snapshot_name) == True
+
     def test_get_mountpoint_returns_none(self):
         assert self.gcpClient.get_mountpoint(invalid_disk_name, "1") is None
 
@@ -683,6 +712,9 @@ class TestGcpClient:
     def test_delete_volume_exception(self):
         pytest.raises(Exception, self.gcpClient._delete_volume,
                       valid_disk_name)
+
+    def test_delete_volume_404_exception(self):
+        assert self.gcpClient._delete_volume(not_found_disk_name) == True
 
     def test_create_attachment(self):
         attachment = self.gcpClient._create_attachment(


### PR DESCRIPTION
* In case of delete operations, the scenario when the object is not found on IaaS providers can be ignored.
* Added this modification for `aws` , `ali`, `azure` and  `gcp`